### PR TITLE
fix(api): Fixed issue where the api may panic when sending emails

### DIFF
--- a/api/src/utils/errors.rs
+++ b/api/src/utils/errors.rs
@@ -445,3 +445,21 @@ impl From<std::convert::Infallible> for ApiError {
         ))
     }
 }
+
+impl From<lettre::error::Error> for ApiError {
+    fn from(error: lettre::error::Error) -> Self {
+        bad_internal!(format!("Email error: {error}"))
+    }
+}
+
+impl From<lettre::transport::smtp::Error> for ApiError {
+    fn from(error: lettre::transport::smtp::Error) -> Self {
+        bad_internal!(format!("Email SMTP error: {error}"))
+    }
+}
+
+impl From<lettre::address::AddressError> for ApiError {
+    fn from(error: lettre::address::AddressError) -> Self {
+        bad_internal!(format!("Parsing email error: {error}"))
+    }
+}

--- a/api/src/utils/shared.rs
+++ b/api/src/utils/shared.rs
@@ -1,6 +1,6 @@
 //! Shared objects and methods across all requests
 use axum::extract::FromRef;
-use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use bb8_redis::{RedisConnectionManager, bb8::Pool};
 use elasticsearch::Elasticsearch;
 use lettre::message::header::ContentType;
 use lettre::message::{IntoBody, Mailbox};
@@ -115,17 +115,16 @@ impl EmailClient {
         body: B,
     ) -> Result<(), ApiError> {
         // try to parse the email address we are sending email too
-        let to = addr.parse().unwrap();
+        let to = addr.parse()?;
         // build the email to send
         let email = lettre::Message::builder()
             .from(self.from.clone())
             .to(to)
             .subject(subject)
             .header(ContentType::TEXT_PLAIN)
-            .body(body)
-            .unwrap();
+            .body(body)?;
         // send our email
-        self.client.send(email).await.unwrap();
+        self.client.send(email).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This was due to unwrapping instead of properly handling errors when sending emails.

Closes #34
