### PR TITLE
fix(api): Readded non zero split fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.2"
+version = "1.1.3"
 authors = ["mcarson <mcarson@sandia.gov>", "gmbaker <gmbaker@sandia.gov>", "jehamza <jehamza@sandia.gov>"]
 edition = "2024"
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -36,14 +36,14 @@ infer = { version = "0.19.0", default-features = false, features = ["std"] }
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version = "1.1.2", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
+thorium = { version = "1.1.3", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
 cgroups-rs = "0.3"
 controlgroup = "0.3"
 
 
 # disable cgroups support when on windows
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version = "1.1.2", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium = { version = "1.1.3", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
 
 
 [features]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -134,7 +134,7 @@ once_cell = { version = "1.21.3", optional = true }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid", "time", "url"], optional = true }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 lettre = { version = "0.11", features = ["tokio1", "tokio1-rustls-tls", "builder", "smtp-transport"], default-features = false, optional = true }
-thorium-derive = { path = "../thorium-derive", version = "1.1.2", optional = true}
+thorium-derive = { path = "../thorium-derive", version = "1.1.3", optional = true}
 percent-encoding = { version = "2.3.1", optional = true }
 dashmap = { version = "6.1", optional = true }
 

--- a/api/src/routes/streams.rs
+++ b/api/src/routes/streams.rs
@@ -1,7 +1,9 @@
+use std::num::NonZeroU64;
+
+use axum::Router;
 use axum::extract::{Json, Path, Query, State};
 use axum::routing::get;
-use axum::Router;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 use utoipa::OpenApi;
 
 use super::OpenApiSecurity;
@@ -71,7 +73,7 @@ pub async fn depth(
         ("stream" = String, Path, description = "The name of the stream to count objects in"),
         ("start" = i64, Path, description = "The starting point in an epoch timestamp to count objects at"),
         ("end" = i64, Path, description = "The ending point in an epoch timestamp to count objects at"),
-        ("split" = i64, Path, description = "How many seconds each chunk should cover"),
+        ("split" = u64, Path, description = "How many seconds each chunk should cover"),
     ),
     responses(
         (status = 200, description = "The number of objects in the stream between start and end time in specified chunks", body = Vec<StreamDepth>),
@@ -90,7 +92,7 @@ pub async fn depth_range(
         String,
         i64,
         i64,
-        i64,
+        NonZeroU64,
     )>,
     State(state): State<AppState>,
 ) -> Result<Json<Vec<StreamDepth>>, ApiError> {

--- a/event-handler/Cargo.toml
+++ b/event-handler/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thorium = {version= "1.1.2", path="../api", default-features = false, features = ["client", "trace"] }
+thorium = {version= "1.1.3", path="../api", default-features = false, features = ["client", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = { version= "1.1.2", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
+thorium = { version= "1.1.3", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
 reqwest = { version = "0.12", features = ["json"]}
 serde = "1.0"
 serde_json = "1.0"

--- a/reactor/Cargo.toml
+++ b/reactor/Cargo.toml
@@ -36,11 +36,11 @@ cfg-if = "1.0.0"
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version= "1.1.2", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
+thorium = { version= "1.1.3", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
 cgroups-rs = "0.3"
 # enable support for kvm based jobs
 virt = { version = "0.4", optional = true }
 
 # disable cgroups support when on windows or macos
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version= "1.1.2", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium = { version= "1.1.3", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}

--- a/scaler/Cargo.toml
+++ b/scaler/Cargo.toml
@@ -14,7 +14,7 @@ test-utilities = []
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = {version= "1.1.2", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
+thorium = {version= "1.1.3", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 async-trait = "0.1"
@@ -43,5 +43,5 @@ hashbrown = "0.15"
 
 [dev-dependencies]
 thorium-scaler = { path = ".", features = ["test-utilities"]}
-thorium = {version= "1.1.2", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
+thorium = {version= "1.1.3", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
 serial_test = "3"

--- a/search-streamer/Cargo.toml
+++ b/search-streamer/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.45", features = ["full"] }
-thorium = { version = "1.1.2", path = "../api", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
+thorium = { version = "1.1.3", path = "../api", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
 chrono = { version = "=0.4.38", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/thoradm/Cargo.toml
+++ b/thoradm/Cargo.toml
@@ -12,7 +12,7 @@ vendored-openssl = ["openssl/vendored"]
 
 
 [dependencies]
-thorium = { version= "1.1.2", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
+thorium = { version= "1.1.3", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
 tokio = { version = "1.45", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 scylla = { version = "1.2", features = ["chrono-04"] }

--- a/thorctl/Cargo.toml
+++ b/thorctl/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
 serde_derive = "1.0"
-thorium = { version = "1.1.2", path = "../api", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
+thorium = { version = "1.1.3", path = "../api", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
 colored = "3"
 owo-colors = "4"
 http = "1.3"

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "description": "Web UI for Thorium 1.x",
   "type": "module",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "scripts": {
     "lint": "node_modules/eslint/bin/eslint.js src",
     "fix": "node_modules/eslint/bin/eslint.js src --fix",


### PR DESCRIPTION
This resolves an issue where non zero splits when getting the depth of a stream in chunks. Giving a 0 would cause this route to panic. Resolves CVE-2025-35435.
