### PR TITLE
feat(thorctl): Added toolbox import functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977eb15ea9efd848bb8a4a1a2500347ed7f0bf794edf0dc3ddcf439f43d36b23"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -348,7 +348,7 @@ checksum = "37672978ae0febce7516ae0a85b53e6185159a9a28787391eb63fc44ec36037d"
 dependencies = [
  "async-fs",
  "futures-lite",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -393,15 +393,16 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.31.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "libloading",
 ]
 
 [[package]]
@@ -556,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147e8eea63a40315d704b97bf9bc9b8c1402ae94f89d5ad6f7550d963309da1b"
+checksum = "734b4282fbb7372923ac339cc2222530f8180d9d4745e582de19a18cee409fd8"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -579,7 +580,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.3",
+ "tokio-rustls 0.26.4",
  "tower",
  "tracing",
 ]
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
  "axum-core",
  "bytes",
@@ -714,8 +715,7 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
@@ -740,7 +740,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -749,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
  "axum",
  "axum-core",
@@ -764,12 +763,12 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "serde",
+ "serde_core",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -796,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -806,7 +805,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -861,7 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5143936af5e1eea1a881e3e3d21b6777da6315e5e307bc3d0c2301c44fa37da9"
 dependencies = [
  "bb8",
- "redis 0.32.5",
+ "redis 0.32.6",
 ]
 
 [[package]]
@@ -1091,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1204,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1214,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1289,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1318,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.16"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef036f0ecf99baef11555578630e2cca559909b4c50822dbba828c252d21c49"
+checksum = "180e549344080374f9b32ed41bf3b6b57885ff6a289367b3dbc10eea8acc1918"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -1568,8 +1567,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1587,12 +1596,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
@@ -1619,9 +1653,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deflate64"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "der"
@@ -1649,12 +1683,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1730,7 +1764,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1937,7 +1971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2263,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
@@ -2339,7 +2373,7 @@ dependencies = [
  "regex",
  "signal-hook",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2352,7 +2386,7 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -2367,7 +2401,7 @@ dependencies = [
  "gix-object",
  "gix-worktree-stream",
  "jiff",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2383,7 +2417,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "unicode-bom",
 ]
 
@@ -2393,7 +2427,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2402,7 +2436,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2428,7 +2462,7 @@ dependencies = [
  "gix-chunk",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2447,7 +2481,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "unicode-bom",
  "winnow",
 ]
@@ -2462,7 +2496,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2479,7 +2513,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2492,7 +2526,7 @@ dependencies = [
  "itoa",
  "jiff",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2516,7 +2550,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2536,7 +2570,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2552,7 +2586,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2573,7 +2607,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "walkdir",
 ]
 
@@ -2595,7 +2629,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2609,7 +2643,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2633,7 +2667,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2685,7 +2719,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2696,7 +2730,7 @@ checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2708,7 +2742,7 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2724,7 +2758,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2744,7 +2778,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -2766,7 +2800,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2784,7 +2818,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "uluru",
 ]
 
@@ -2797,7 +2831,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2809,7 +2843,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2823,7 +2857,7 @@ dependencies = [
  "gix-validate",
  "home",
  "once_cell",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2838,7 +2872,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2851,7 +2885,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2869,7 +2903,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -2881,7 +2915,7 @@ checksum = "4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2901,7 +2935,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -2916,7 +2950,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2934,7 +2968,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2949,7 +2983,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2973,7 +3007,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2996,7 +3030,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3011,7 +3045,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3049,7 +3083,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3066,7 +3100,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3079,7 +3113,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "url",
 ]
 
@@ -3101,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3140,7 +3174,7 @@ dependencies = [
  "gix-path",
  "gix-worktree",
  "io-close",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3158,7 +3192,7 @@ dependencies = [
  "gix-path",
  "gix-traverse",
  "parking_lot",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3539,7 +3573,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls 0.26.3",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -3573,7 +3607,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.3",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -3645,7 +3679,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.62.1",
 ]
 
 [[package]]
@@ -3960,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4001,7 +4035,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4087,7 +4121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tower",
@@ -4111,7 +4145,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4120,7 +4154,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "079fc8c1c397538628309cfdee20696ebdcc26745f9fb17f89b78782205bd995"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "serde",
@@ -4149,7 +4183,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4221,7 +4255,7 @@ dependencies = [
  "rustls 0.23.32",
  "socket2 0.6.0",
  "tokio",
- "tokio-rustls 0.26.3",
+ "tokio-rustls 0.26.4",
  "url",
  "webpki-roots",
 ]
@@ -4234,9 +4268,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libgit2-sys"
@@ -4259,14 +4293,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "liblzma"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bf66f4598dc77ff96677c8e763655494f00ff9c1cf79e2eb5bb07bc31f807d"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
 dependencies = [
  "liblzma-sys",
 ]
@@ -4418,9 +4452,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
@@ -4637,9 +4671,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -4699,9 +4733,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.2+3.5.2"
+version = "300.5.3+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
 dependencies = [
  "cc",
 ]
@@ -4743,7 +4777,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -4806,7 +4840,7 @@ dependencies = [
  "opentelemetry_sdk 0.30.0",
  "prost",
  "reqwest",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tonic",
  "tracing",
@@ -4868,7 +4902,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -4914,9 +4948,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -5014,7 +5048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -5252,7 +5286,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.32",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -5273,7 +5307,7 @@ dependencies = [
  "rustls 0.23.32",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5295,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -5485,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd3650deebc68526b304898b192fa4102a4ef0b9ada24da096559cb60e0eef8"
+checksum = "15965fbccb975c38a08a68beca6bdb57da9081cd0859417c5975a160d968c3cb"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5531,23 +5565,23 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5556,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5568,9 +5602,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5635,7 +5669,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.3",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5853,7 +5887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5879,7 +5913,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -5918,7 +5952,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.4.0",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -5961,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.14",
@@ -6007,7 +6041,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6093,7 +6127,7 @@ dependencies = [
  "scylla-cql",
  "smallvec",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "uuid",
@@ -6113,7 +6147,7 @@ dependencies = [
  "scylla-macros",
  "snap",
  "stable_deref_trait",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "uuid",
  "yoke",
@@ -6125,7 +6159,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162aed3aa5b6985d121d9e7e4137efebd49645dee204962b2e9ab85176349119"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6181,9 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
@@ -6214,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6246,18 +6280,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6318,7 +6352,7 @@ checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6344,9 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6364,11 +6398,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6758,15 +6792,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6790,11 +6824,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -6810,9 +6844,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6821,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "thoradm"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6845,7 +6879,7 @@ dependencies = [
  "kanal",
  "num-format",
  "openssl",
- "redis 0.32.5",
+ "redis 0.32.6",
  "rkyv",
  "scylla",
  "serde",
@@ -6861,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "thorctl"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "async-walkdir",
@@ -6888,6 +6922,7 @@ dependencies = [
  "owo-colors",
  "rand 0.9.2",
  "regex",
+ "reqwest",
  "rpassword",
  "semver",
  "serde",
@@ -6905,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "thorium"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -6968,7 +7003,7 @@ dependencies = [
  "opentelemetry_sdk 0.30.0",
  "percent-encoding",
  "rand 0.9.2",
- "redis 0.32.5",
+ "redis 0.32.6",
  "regex",
  "reqwest",
  "rkyv",
@@ -7009,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-agent"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7044,9 +7079,9 @@ dependencies = [
 
 [[package]]
 name = "thorium-derive"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -7054,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-event-handler"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -7069,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-operator"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
@@ -7099,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-reactor"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -7124,7 +7159,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-scaler"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7158,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-search-streamer"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7342,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.32",
  "tokio",
@@ -7913,9 +7948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7926,9 +7961,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -7940,9 +7975,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7953,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7963,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7976,9 +8011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -7998,9 +8033,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8047,7 +8082,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -8093,9 +8128,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -8117,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8128,9 +8163,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8230,14 +8265,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link 0.2.0",
 ]
@@ -8260,11 +8295,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -8429,9 +8464,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
@@ -8521,9 +8556,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 authors = ["mcarson <mcarson@sandia.gov>", "gmbaker <gmbaker@sandia.gov>", "jehamza <jehamza@sandia.gov>"]
 edition = "2024"
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -36,14 +36,14 @@ infer = { version = "0.19.0", default-features = false, features = ["std"] }
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version = "1.2.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
+thorium = { version = "1.3.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
 cgroups-rs = "0.3"
 controlgroup = "0.3"
 
 
 # disable cgroups support when on windows
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version = "1.2.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium = { version = "1.3.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
 
 
 [features]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -134,7 +134,7 @@ once_cell = { version = "1.21.3", optional = true }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid", "time", "url"], optional = true }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 lettre = { version = "0.11", features = ["tokio1", "tokio1-rustls-tls", "builder", "smtp-transport"], default-features = false, optional = true }
-thorium-derive = { path = "../thorium-derive", version = "1.2.0", optional = true}
+thorium-derive = { path = "../thorium-derive", version = "1.3.0", optional = true}
 percent-encoding = { version = "2.3.1", optional = true }
 dashmap = { version = "6.1", optional = true }
 

--- a/event-handler/Cargo.toml
+++ b/event-handler/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thorium = {version= "1.2.0", path="../api", default-features = false, features = ["client", "trace"] }
+thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = { version= "1.2.0", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
+thorium = { version= "1.3.0", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
 reqwest = { version = "0.12", features = ["json"]}
 serde = "1.0"
 serde_json = "1.0"

--- a/reactor/Cargo.toml
+++ b/reactor/Cargo.toml
@@ -36,11 +36,11 @@ cfg-if = "1.0.0"
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version= "1.2.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
+thorium = { version= "1.3.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
 cgroups-rs = "0.3"
 # enable support for kvm based jobs
 virt = { version = "0.4", optional = true }
 
 # disable cgroups support when on windows or macos
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version= "1.2.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium = { version= "1.3.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}

--- a/scaler/Cargo.toml
+++ b/scaler/Cargo.toml
@@ -14,7 +14,7 @@ test-utilities = []
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = {version= "1.2.0", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
+thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 async-trait = "0.1"
@@ -43,5 +43,5 @@ hashbrown = "0.15"
 
 [dev-dependencies]
 thorium-scaler = { path = ".", features = ["test-utilities"]}
-thorium = {version= "1.2.0", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
+thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
 serial_test = "3"

--- a/search-streamer/Cargo.toml
+++ b/search-streamer/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.45", features = ["full"] }
-thorium = { version = "1.2.0", path = "../api", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
+thorium = { version = "1.3.0", path = "../api", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
 chrono = { version = "=0.4.38", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/thoradm/Cargo.toml
+++ b/thoradm/Cargo.toml
@@ -12,7 +12,7 @@ vendored-openssl = ["openssl/vendored"]
 
 
 [dependencies]
-thorium = { version= "1.2.0", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
+thorium = { version= "1.3.0", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
 tokio = { version = "1.45", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 scylla = { version = "1.2", features = ["chrono-04"] }

--- a/thoradm/src/args.rs
+++ b/thoradm/src/args.rs
@@ -77,7 +77,6 @@ fn default_backup_components() -> Vec<BackupComponents> {
 }
 
 /// The tables that can be backed up
-// JEHAMZA_TODO: wish this was dynamic...
 #[derive(Debug, Clone, Copy, strum::Display, ValueEnum, PartialEq, Eq, Hash)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BackupComponents {

--- a/thorctl/Cargo.toml
+++ b/thorctl/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
 serde_derive = "1.0"
-thorium = { version = "1.2.0", path = "../api", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
+thorium = { version = "1.3.0", path = "../api", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
 colored = "3"
 owo-colors = "4"
 http = "1.3"
@@ -45,6 +45,7 @@ semver = { version = "1", features = ["serde"] }
 dialoguer = "0.11"
 dirs = "6"
 cfg-if = "1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 
 [features]

--- a/thorctl/src/args.rs
+++ b/thorctl/src/args.rs
@@ -21,7 +21,7 @@ use self::{
     tags::Tags,
     uncart::Uncart,
 };
-use crate::utils::repos::validate_repo_url;
+use crate::{args::toolbox::Toolbox, utils::repos::validate_repo_url};
 
 pub mod cart;
 pub mod clusters;
@@ -37,6 +37,7 @@ pub mod repos;
 pub mod results;
 pub mod run;
 pub mod tags;
+pub mod toolbox;
 mod traits;
 pub mod uncart;
 
@@ -137,6 +138,9 @@ pub enum SubCommands {
     /// Modify the Thorctl config file indicated by `--config`
     #[clap(version, author)]
     Config(Config),
+    /// Perform toolbox related tasks
+    #[clap(version, author, subcommand)]
+    Toolbox(Toolbox),
 }
 
 /// The mode our command is in

--- a/thorctl/src/args/toolbox.rs
+++ b/thorctl/src/args/toolbox.rs
@@ -1,0 +1,48 @@
+//! Arguments for toolbox-related Thorctl commands
+
+use clap::Parser;
+use std::path::PathBuf;
+use url::Url;
+
+/// A command to interact with Thorium toolboxes
+#[derive(Parser, Debug)]
+pub enum Toolbox {
+    /// Import a toolbox into Thorium
+    ///
+    /// A Thorium toolbox is an external collection of tools and pipelines pre-configured
+    /// and ready to run in Thorium
+    #[clap(version, author)]
+    Import(ImportToolbox),
+}
+
+/// The location of the toolbox manifest, either by URL or by file path
+#[derive(Debug, Clone)]
+pub enum ManifestLocation {
+    /// The manifest is at this URL
+    Url(Url),
+    /// The manifest is at this file path
+    Path(PathBuf),
+}
+
+impl std::str::FromStr for ManifestLocation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // try parsing as a URL first
+        if let Ok(url) = Url::parse(s) {
+            return Ok(Self::Url(url));
+        }
+        // if URL parsing fails, treat it as a file path
+        Ok(Self::Path(PathBuf::from(s)))
+    }
+}
+
+/// Download a toolbox manifest and import it into Thorium
+#[derive(Parser, Debug)]
+pub struct ImportToolbox {
+    /// The URL or file path on the system where the toolbox manifest is found
+    pub manifest: ManifestLocation,
+    /// Skip the confirmation dialog
+    #[clap(short = 'y', long)]
+    pub skip_confirm: bool,
+}

--- a/thorctl/src/handlers.rs
+++ b/thorctl/src/handlers.rs
@@ -14,6 +14,7 @@ pub mod repos;
 pub mod results;
 pub mod run;
 pub mod tags;
+pub mod toolbox;
 pub mod uncart;
 pub mod update;
 mod worker;

--- a/thorctl/src/handlers/progress.rs
+++ b/thorctl/src/handlers/progress.rs
@@ -17,8 +17,7 @@ pub enum BarKind {
     /// An unbounded IO bar
     UnboundIO,
     /// An IO bar
-    #[allow(dead_code)]
-    IO,
+    IO(u64),
 }
 
 impl BarKind {
@@ -58,11 +57,25 @@ impl BarKind {
                 // start this bars progress at 0
                 bar.set_position(0);
             }
-            BarKind::UnboundIO | BarKind::IO => {
+            BarKind::UnboundIO => {
                 // build our style string
                 let style = format!(
                     "[{{elapsed_precise}}] {name} {{msg}} {{bytes}} {{binary_bytes_per_sec}}"
                 );
+                // set the style for our bar
+                bar.set_style(ProgressStyle::with_template(&style).unwrap());
+                // start this bars progress at 0
+                bar.set_position(0);
+            }
+            BarKind::IO(bound) => {
+                // build our style string
+                let style = format!(
+                    "[{{elapsed_precise}}] {name} {{msg}} {{bytes}}/{{total_bytes}} {{binary_bytes_per_sec}}"
+                );
+                // set this bars length
+                bar.set_length(bound);
+                // start this bars progress at 0
+                bar.set_position(0);
                 // set the style for our bar
                 bar.set_style(ProgressStyle::with_template(&style).unwrap());
             }
@@ -289,6 +302,11 @@ impl Bar {
         kind.setup(&self.name, &self.bar);
         // set our new message
         self.bar.set_message(msg);
+    }
+
+    /// Finish the bar, leaving its message displayed
+    pub fn finish(&self) {
+        self.bar.finish();
     }
 
     /// Finish this bar with an updated message

--- a/thorctl/src/handlers/toolbox.rs
+++ b/thorctl/src/handlers/toolbox.rs
@@ -1,0 +1,27 @@
+//! Handles toolbox commands
+
+use thorium::Error;
+
+mod import;
+mod manifest;
+
+use crate::args::toolbox::Toolbox;
+use crate::args::Args;
+use crate::handlers::update;
+use crate::utils;
+
+pub async fn handle(args: &Args, toolbox: &Toolbox) -> Result<(), Error> {
+    // load our config and instance our client
+    let (conf, thorium) = utils::get_client(args).await?;
+    // warn about insecure connections if not set to skip
+    if !conf.skip_insecure_warning.unwrap_or_default() {
+        utils::warn_insecure_conf(&conf)?;
+    }
+    // check if we need to update
+    if !args.skip_update && !conf.skip_update.unwrap_or_default() {
+        update::ask_update(&thorium).await?;
+    }
+    match toolbox {
+        Toolbox::Import(cmd) => import::import(thorium, conf, cmd).await,
+    }
+}

--- a/thorctl/src/handlers/toolbox/import.rs
+++ b/thorctl/src/handlers/toolbox/import.rs
@@ -1,0 +1,385 @@
+use colored::Colorize;
+use futures::{stream, StreamExt, TryStreamExt};
+use reqwest::header::CONTENT_LENGTH;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use thorium::models::GroupRequest;
+use thorium::{CtlConf, Error, Thorium};
+use tokio::io::AsyncReadExt;
+use url::Url;
+
+use super::manifest::{ImageManifest, PipelineManifest, ToolboxManifest};
+use crate::args::toolbox::{ImportToolbox, ManifestLocation};
+use crate::handlers::progress::{Bar, BarKind};
+
+/// Proceed on 409 CONFLICT errors, printing the given
+/// message to stdout if we get a 409
+macro_rules! proceed_on_conflict {
+    ($fallible:expr, $progress:expr, $($arg:tt)*) => {{
+        match $fallible {
+            Ok(_) => Ok(()),
+            Err(err) => match err.status() {
+                Some(status) => {
+                    if status == http::StatusCode::CONFLICT {
+                        // print a log line to the progress bar
+                        $progress.info_anonymous(format!($($arg)*));
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                }
+                None => Err(err),
+            },
+        }
+    }};
+}
+
+/// Import the manifest's images
+///
+/// # Arguments
+///
+/// * `thorium` - The Thorium client
+/// * `images` - The images to import
+/// * `progress` - The progress bar
+async fn import_images(
+    thorium: &Thorium,
+    images: &HashMap<String, ImageManifest>,
+    progress: &Bar,
+) -> Result<(), Error> {
+    // make an iterator over each image to create
+    let image_iter = images.iter().flat_map(|(image_name, manifest)| {
+        manifest
+            .versions
+            .iter()
+            .map(move |(version_name, image)| (image_name, version_name, image))
+    });
+    progress.refresh(
+        "Importing images",
+        BarKind::Bound(image_iter.clone().count() as u64),
+    );
+    // create the images concurrently
+    stream::iter(image_iter)
+        .map(Ok::<_, Error>)
+        .try_for_each_concurrent(10, |(image_name, version_name, image)| async move {
+            proceed_on_conflict!(
+                thorium.images.create(&image.config).await,
+                progress,
+                "image '{}:{}' already exists in group '{}'! Skipping import...",
+                image_name.bright_yellow(),
+                version_name.bright_yellow(),
+                image.config.group.bright_yellow()
+            )
+            .map_err(|err| {
+                Error::new(format!(
+                    "Error importing image '{image_name}:{version_name}': {err}"
+                ))
+            })?;
+            progress.inc(1);
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}
+
+/// Import the manifest's pipelines
+///
+/// # Arguments
+///
+/// * `thorium` - The Thorium client
+/// * `pipelines` - The pipelines to import
+/// * `progress` - The progress bar
+async fn import_pipelines(
+    thorium: &Thorium,
+    pipelines: &HashMap<String, PipelineManifest>,
+    progress: &Bar,
+) -> Result<(), Error> {
+    // make an iterator over each pipeline to create
+    let pipeline_iter = pipelines.iter().flat_map(|(pipeline_name, manifest)| {
+        manifest
+            .versions
+            .iter()
+            .map(move |(version_name, pipeline)| (pipeline_name, version_name, pipeline))
+    });
+    progress.refresh(
+        "Importing pipelines",
+        BarKind::Bound(pipeline_iter.clone().count() as u64),
+    );
+    // create the pipelines concurrently
+    stream::iter(pipeline_iter)
+        .map(Ok::<_, Error>)
+        .try_for_each_concurrent(10, |(pipeline_name, version_name, pipeline)| async move {
+            proceed_on_conflict!(
+                thorium.pipelines.create(&pipeline.config).await,
+                progress,
+                "Pipeline '{}:{}' already exists in group '{}'! Skipping import...",
+                pipeline_name.bright_yellow(),
+                version_name.bright_yellow(),
+                pipeline.config.group.bright_yellow()
+            )
+            .map_err(|err| {
+                Error::new(format!(
+                    "Error importing pipeline '{pipeline_name}:{version_name}': {err}"
+                ))
+            })?;
+            progress.inc(1);
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}
+
+/// Create any groups the manifest expects to exist that are missing in the
+/// Thorium instance
+///
+/// # Arguments
+///
+/// * `thorium` - The Thorium client
+/// * `manifest_groups` - The groups the manifest expects to exist
+/// * `progress` - The progress bar
+async fn create_missing_groups(
+    thorium: &Thorium,
+    mut manifest_groups: HashSet<String>,
+    progress: &Bar,
+) -> Result<(), Error> {
+    // get all existing groups already in Thorium
+    let mut thorium_groups = HashSet::new();
+    // use a very large limit to make sure we get all groups
+    let mut cursor = thorium.groups.list().limit(1_000_000);
+    loop {
+        cursor
+            .next()
+            .await
+            .map_err(|err| Error::new(format!("Error listing groups: {err}")))?;
+        thorium_groups.extend(cursor.names.drain(..));
+        if cursor.exhausted {
+            break;
+        }
+    }
+    // calculate which groups are missing
+    let missing_groups: Vec<String> = manifest_groups
+        .extract_if(|manifest_group| !thorium_groups.contains(manifest_group))
+        .collect();
+    if !missing_groups.is_empty() {
+        progress.refresh(
+            "Importing groups",
+            BarKind::Bound(missing_groups.len() as u64),
+        );
+        // create all the missing groups;
+        // we only want to create the groups that are needed because group create
+        // returns a 401 rather than a 409 if the group already exists
+        stream::iter(missing_groups)
+            .map(Ok::<_, Error>)
+            .try_for_each_concurrent(10, |missing_group| async {
+                let group_request = GroupRequest::new(missing_group);
+                thorium.groups.create(&group_request).await?;
+                progress.inc(1);
+                Ok(())
+            })
+            .await
+            .map_err(|err| Error::new(format!("Error creating missing groups: {err}")))?;
+    }
+    Ok(())
+}
+
+/// Confirm the manifest with the user
+///
+/// # Arguments
+///
+/// * `thorium` - The Thorium client
+/// * `conf` - The Thorctl config
+/// * `manifest` - The manifest to confirm
+/// * `manifest_groups` - The groups the manifest expects to exist
+async fn confirm_manifest(
+    thorium: &Thorium,
+    conf: &CtlConf,
+    manifest: &ToolboxManifest,
+    manifest_groups: &HashSet<String>,
+) -> Result<bool, Error> {
+    // get info on the current user
+    let current_user = thorium
+        .users
+        .info()
+        .await
+        .map_err(|err| Error::new(format!("Error getting current user info: {err}")))?;
+    // display the manifest's info
+    println!("{}", "Images:".bright_yellow());
+    for image_name in manifest.images.keys() {
+        println!("  {image_name}");
+    }
+    println!("\n{}", "Pipelines:".bright_yellow());
+    for pipeline_name in manifest.pipelines.keys() {
+        println!("  {pipeline_name}");
+    }
+    println!("\n{}", "Groups:".bright_yellow());
+    for group in manifest_groups {
+        println!("  {group}");
+    }
+    println!();
+    // confirm with the user that they want to import
+    let response = dialoguer::Confirm::new()
+        .with_prompt(format!(
+            "Import the above items to Thorium instance at '{}' as user '{}'?",
+            conf.keys.api.bright_green(),
+            current_user.username.bright_green()
+        ))
+        .interact()?;
+    Ok(response)
+}
+
+/// Read and parse the manifest file at the given URL
+///
+/// # Arguments
+///
+/// * `url` - The manifest URL
+/// * `progress` - The progress bar
+async fn get_manifest_from_url(url: &Url, progress: &Bar) -> Result<ToolboxManifest, Error> {
+    // get the manifest file from the URL
+    let resp = reqwest::get(url.clone())
+        .await
+        .map_err(|err| Error::new(format!("Error downloading toolbox manifest: {err}")))?;
+    // check if the response was an error
+    match resp.error_for_status() {
+        Ok(resp) => {
+            // try to get the content length for the progress bar
+            if let Some(content_length) = resp.content_length().or(resp
+                .headers()
+                .get(CONTENT_LENGTH)
+                .and_then(|content_length_header| {
+                    println!("Got content length header");
+                    content_length_header.to_str().ok()
+                })
+                .and_then(|content_length_str| {
+                    println!("Got content length str: {content_length_str}");
+                    content_length_str.parse::<u64>().ok()
+                }))
+            {
+                progress.refresh("Downloading manifest...", BarKind::IO(content_length));
+            } else {
+                progress.refresh("Downloading manifest...", BarKind::UnboundIO);
+            }
+            // get the manifest file as bytes;
+            // we use serde_json here instead of reqwest's JSON capabilities for
+            // better error logging
+            let mut manifest_bytes = Vec::new();
+            let mut manifest_bytes_stream = resp.bytes_stream();
+            while let Some(bytes) = manifest_bytes_stream.next().await {
+                let bytes = bytes.map_err(|err| {
+                    Error::new(format!(
+                        "Error downloading toolbox manifest response body: {err}"
+                    ))
+                })?;
+                progress.inc(bytes.len() as u64);
+                manifest_bytes.extend_from_slice(&bytes);
+            }
+            // parse the manifest data
+            serde_json::from_slice(&manifest_bytes)
+                .map_err(|err| Error::new(format!("Malformed toolbox manifest: {err}")))
+        }
+        Err(err) => Err(Error::new(format!(
+            "Error downloading toolbox manifest: {err}"
+        ))),
+    }
+}
+
+/// Read and parse the manifest file at the given path
+///
+/// # Arguments
+///
+/// * `path` - The manifest file path
+/// * `progress` - The progress bar
+async fn get_manifest_from_path(path: &Path, progress: &Bar) -> Result<ToolboxManifest, Error> {
+    // open the manifest file at the path
+    let mut manifest_file = tokio::fs::File::open(path).await.map_err(|err| {
+        Error::new(format!(
+            "Error opening manifest file '{}': {}",
+            path.display(),
+            err
+        ))
+    })?;
+    // try to get the file's length
+    match manifest_file
+        .metadata()
+        .await
+        .ok()
+        .map(|metadata| metadata.len())
+    {
+        Some(file_len) => progress.refresh("Reading manifest file...", BarKind::IO(file_len)),
+        None => progress.refresh("Reading manifest file...", BarKind::UnboundIO),
+    }
+    // read the file
+    let mut manifest_bytes = Vec::new();
+    loop {
+        let bytes_read = manifest_file
+            .read_buf(&mut manifest_bytes)
+            .await
+            .map_err(|err| {
+                Error::new(format!(
+                    "Error reading manifest file '{}': {}",
+                    path.display(),
+                    err
+                ))
+            })?;
+        if bytes_read == 0 {
+            break;
+        }
+        progress.inc(bytes_read as u64);
+    }
+    // parse the manifest file
+    serde_json::from_slice(&manifest_bytes)
+        .map_err(|err| Error::new(format!("Malformed toolbox manifest file: {err}")))
+}
+
+/// Import a toolbox into Thorium by the given manifest file
+///
+/// # Arguments
+///
+/// * `thorium` - The Thorium client
+/// * `conf` - The Thorctl config
+/// * `cmd` - The toolbox import command that was run
+pub async fn import(thorium: Thorium, conf: CtlConf, cmd: &ImportToolbox) -> Result<(), Error> {
+    // get the toolbox manifest by URL or file path
+    let (manifest, progress) = match &cmd.manifest {
+        ManifestLocation::Url(manifest_url) => {
+            // create the progress bar
+            let progress = Bar::new("", "Downloading manifest...", BarKind::UnboundIO);
+            let manifest = get_manifest_from_url(manifest_url, &progress).await?;
+            (manifest, progress)
+        }
+        ManifestLocation::Path(manifest_path) => {
+            // create the progress bar
+            let progress = Bar::new("", "Reading manifest file...", BarKind::UnboundIO);
+            let manifest = get_manifest_from_path(manifest_path, &progress).await?;
+            (manifest, progress)
+        }
+    };
+    // validate the manifest besides just its formatting
+    if let Err(err) = manifest.validate() {
+        return Err(Error::new(format!(
+            "Invalid toolbox manifest: {}",
+            err.msg().unwrap_or_else(|| "Unknown error".to_string())
+        )));
+    }
+    // get all the groups the manifest expects to exist
+    let manifest_groups = manifest.groups();
+    // confirm with the user it's okay to import the manifest
+    if !cmd.skip_confirm {
+        let confirmed = confirm_manifest(&thorium, &conf, &manifest, &manifest_groups).await?;
+        if !confirmed {
+            return Ok(());
+        }
+    }
+    // create any groups the manifest expects that Thorium doesn't yet have
+    create_missing_groups(&thorium, manifest_groups, &progress).await?;
+    // first import the manifest's images
+    import_images(&thorium, &manifest.images, &progress)
+        .await
+        .map_err(|err| Error::new(format!("Error importing images: {err}")))?;
+    // then import the manifest's pipelines
+    import_pipelines(&thorium, &manifest.pipelines, &progress)
+        .await
+        .map_err(|err| Error::new(format!("Error importing pipelines: {err}")))?;
+    // inform the user the import is complete
+    progress.refresh("Import complete!", BarKind::Timer);
+    progress.finish();
+    Ok(())
+}

--- a/thorctl/src/handlers/toolbox/manifest.rs
+++ b/thorctl/src/handlers/toolbox/manifest.rs
@@ -1,0 +1,120 @@
+//! The toolbox manifest structure
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use thorium::models::{ImageRequest, PipelineRequest};
+use thorium::Error;
+
+/// A toolbox manifest – a description of pipelines and images that
+/// can be imported into Thorium
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolboxManifest {
+    /// The name of this toolbox
+    pub name: String,
+    /// The registry the images can be found at
+    pub registry: String,
+    /// A map of pipeline names to their details
+    pub pipelines: HashMap<String, PipelineManifest>,
+    /// A map of image names to their details
+    pub images: HashMap<String, ImageManifest>,
+}
+
+impl ToolboxManifest {
+    /// Validate the toolbox manifest
+    pub fn validate(&self) -> Result<(), Error> {
+        // validate the manifest's pipelines
+        self.validate_pipelines()?;
+        Ok(())
+    }
+
+    /// Validate the manifest's pipelines
+    fn validate_pipelines(&self) -> Result<(), Error> {
+        // make sure all pipelines' requested images are in the manifest
+        let mut pipelines_missing_images: HashMap<String, Vec<String>> = HashMap::new();
+        for (pipeline_name, pipeline_manifest) in &self.pipelines {
+            for pipeline_version in pipeline_manifest.versions.values() {
+                for (image_name, image_version) in &pipeline_version.images {
+                    match self.images.get(image_name) {
+                        Some(image) => {
+                            if !image.versions.contains_key(&image_version.version) {
+                                // the pipeline requires a specific image version that isn't in the manifest
+                                pipelines_missing_images
+                                    .entry(pipeline_name.clone())
+                                    .or_default()
+                                    .push(format!("{}:{}", image_name, image_version.version));
+                            }
+                        }
+                        None => {
+                            // the pipeline requires an image that isn't in the manifest
+                            pipelines_missing_images
+                                .entry(pipeline_name.clone())
+                                .or_default()
+                                .push(image_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+        if !pipelines_missing_images.is_empty() {
+            return Err(Error::new(format!("One or more pipelines require images not found in the manifest: {pipelines_missing_images:?}")));
+        }
+        Ok(())
+    }
+
+    /// Returns all of the groups the manifest expects to exist
+    pub fn groups(&self) -> HashSet<String> {
+        self.pipelines
+            .values()
+            .flat_map(|pipeline_manifest| pipeline_manifest.versions.values())
+            .map(|pipeline_version| &pipeline_version.config.group)
+            .chain(
+                self.images
+                    .values()
+                    .flat_map(|image_manifest| image_manifest.versions.values())
+                    .map(|image_version| &image_version.config.group),
+            )
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineManifest {
+    /// A map of pipeline versions to their details
+    #[serde(flatten)]
+    pub versions: HashMap<String, PipelineVersion>,
+}
+
+/// Details for a specific pipeline version
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineVersion {
+    /// A description of the pipeline for the purpose of the toolbox, not for
+    /// Thorium itself
+    pub description: String,
+    /// A map of image names to their info for the pipeline
+    pub images: HashMap<String, PipelineImage>,
+    /// The pipeline's Thorium configuration
+    pub config: PipelineRequest,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineImage {
+    /// The version of the image this pipeline expects
+    pub version: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageManifest {
+    /// A map of image versions to their details
+    #[serde(flatten)]
+    pub versions: HashMap<String, ImageVersion>,
+}
+
+/// Details for a specific image version
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageVersion {
+    /// The image's build path relative to the toolbox manifest's location
+    pub build_path: String,
+    /// The image's Thorium config
+    pub config: ImageRequest,
+}

--- a/thorctl/src/main.rs
+++ b/thorctl/src/main.rs
@@ -37,6 +37,7 @@ async fn main() {
         SubCommands::Run(run) => handlers::run::handle(&args, run).await,
         SubCommands::Update => handlers::update::update(&args).await,
         SubCommands::Config(config) => handlers::config::config(&args, config),
+        SubCommands::Toolbox(toolbox) => handlers::toolbox::handle(&args, toolbox).await,
     } {
         // print the error
         eprintln!("{err}");


### PR DESCRIPTION
Added 'thorctl toolbox import' command to quickly import tool/pipeline configurations from toolbox manifest files. This adds just the basic import functionality with no docs or caching functionality. Eventually this subcommand can expand to a sort of package manager for Thorium to add and update tools/pipelines, but none of that is included here.