### PR TITLE
Update ExifTool version in Dockerfile

### DIFF
--- a/tools/images/exiftool.org/tools/exiftool/Dockerfile
+++ b/tools/images/exiftool.org/tools/exiftool/Dockerfile
@@ -8,10 +8,11 @@ RUN apt update && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://exiftool.org/Image-ExifTool-13.38.tar.gz /app/
+# NOTE: Check ExifTool official site for latest version; 13.38 may not be available. Latest version: 13.40
+ADD https://exiftool.org/Image-ExifTool-13.40.tar.gz /app/
 
-RUN tar -xzvf Image-ExifTool-13.38.tar.gz && \
-    rm Image-ExifTool-13.38.tar.gz
+RUN tar -xzvf Image-ExifTool-13.40.tar.gz && \
+    rm Image-ExifTool-13.40.tar.gz
 
 COPY run_exiftool.py /app/.
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# Fix ExifTool Dockerfile: update version and add guidance note #

## 🗣 Description ##

The current Dockerfile at `thorium/tools/images/exiftool.org/tools/exiftool/Dockerfile` fails during build because it tries to download ExifTool version 13.38, which is no longer available on the official site.  

Changes in this PR:
- Added a comment to guide users to check the official ExifTool website for the latest version.
- Updated the `ADD` line to use version 13.40 of ExifTool to prevent build errors.
- No other changes to the Dockerfile.

## 💭 Motivation and context ##

Version 13.38 of ExifTool results in a `404 Not Found` error:

ADD failed: ... 404 Not Found


Updating to a currently available version ensures the Docker image can be built successfully.  
This also provides guidance for future maintainers to check the official site for version updates.  

Related reference: [ExifTool official site](https://exiftool.org/)

## 🧪 Testing ##

Tested by building the Docker image locally:

```bash
docker build -t thorium/exiftool .

The build completes successfully using version 13.40.
Anyone else can test by building the Dockerfile after applying these changes.
Pre-approval checklist:
This PR has an informative and human-readable title.
Changes are limited to a single goal - eschew scope creep!
All future TODOs are captured in issues, which are referenced in code comments.
All relevant type-of-change labels have been added.
This PR has an informative and human-readable title.</p>
Changes are limited to a single goal - <em data-start="2013" data-end="2034">eschew scope creep!</em></p>
future TODOs are captured in issues, which are referenced in code comments.</p>
All relevant type-of-change labels have been added.</p>
All relevant repo and/or project documentation has been updated to reflect the changes in this PR.</p>
Post-merge checklist:
Create a release (necessary if and only if the version was bumped).