### PR TITLE
fix(thorium): Migrated to astra-tokio-tar to resolve cve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,7 +4340,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4987,7 +5003,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -5537,15 +5553,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6855,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "thoradm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6887,7 +6894,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "strum",
- "thorium",
+ "thorium-api",
  "tokio",
  "tokio-util",
  "uuid",
@@ -6895,7 +6902,7 @@ dependencies = [
 
 [[package]]
 name = "thorctl"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "async-walkdir",
@@ -6930,7 +6937,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "thorium",
+ "thorium-api",
  "tokio",
  "tokio-stream",
  "url",
@@ -6939,12 +6946,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "thorium"
-version = "1.3.0"
+name = "thorium-agent"
+version = "1.3.1"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "cart-rs",
+ "cgroups-rs",
+ "chrono",
+ "clap",
+ "config",
+ "controlgroup",
+ "crossbeam",
+ "dirs",
+ "futures 0.3.31",
+ "gethostname",
+ "infer",
+ "itertools 0.14.0",
+ "openssl",
+ "opentelemetry 0.30.0",
+ "path-clean",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sysinfo",
+ "thorium-api",
+ "tokio",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "thorium-api"
+version = "1.3.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "argon2",
+ "astral-tokio-tar",
  "async-recursion",
  "async-trait",
  "async_once",
@@ -7025,7 +7068,6 @@ dependencies = [
  "thorium-derive",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-test",
  "tokio-util",
  "tower",
@@ -7043,43 +7085,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "thorium-agent"
-version = "1.3.0"
-dependencies = [
- "async-trait",
- "bincode",
- "cart-rs",
- "cgroups-rs",
- "chrono",
- "clap",
- "config",
- "controlgroup",
- "crossbeam",
- "dirs",
- "futures 0.3.31",
- "gethostname",
- "infer",
- "itertools 0.14.0",
- "openssl",
- "opentelemetry 0.30.0",
- "path-clean",
- "regex",
- "reqwest",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "sysinfo",
- "thorium",
- "tokio",
- "tracing",
- "uuid",
- "walkdir",
-]
-
-[[package]]
 name = "thorium-derive"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -7089,14 +7096,14 @@ dependencies = [
 
 [[package]]
 name = "thorium-event-handler"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "clap",
  "futures 0.3.31",
  "futures-locks",
  "reqwest",
- "thorium",
+ "thorium-api",
  "tokio",
  "tracing",
  "uuid",
@@ -7104,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-operator"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
@@ -7127,14 +7134,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "thorium",
+ "thorium-api",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "thorium-reactor"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -7150,7 +7157,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sysinfo",
- "thorium",
+ "thorium-api",
  "tokio",
  "tracing",
  "uuid",
@@ -7159,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-scaler"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7184,7 +7191,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
- "thorium",
+ "thorium-api",
  "thorium-scaler",
  "tokio",
  "tracing",
@@ -7193,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-search-streamer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7210,7 +7217,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "thorium",
+ "thorium-api",
  "tokio",
  "tracing",
  "url",
@@ -7394,21 +7401,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1"
 authors = ["mcarson <mcarson@sandia.gov>", "gmbaker <gmbaker@sandia.gov>", "jehamza <jehamza@sandia.gov>"]
 edition = "2024"
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -36,14 +36,14 @@ infer = { version = "0.19.0", default-features = false, features = ["std"] }
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version = "1.3.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
+thorium-api = { path = "../api", version = "1.3.1", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace"]}
 cgroups-rs = "0.3"
 controlgroup = "0.3"
 
 
 # disable cgroups support when on windows
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version = "1.3.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium-api = { path = "../api", version = "1.3.1", default-features = false, features = ["client", "crossbeam-err", "trace"]}
 
 
 [features]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "thorium"
+name = "thorium-api"
 resolver = "2"
 version = { workspace = true }
 authors = { workspace = true }
@@ -25,7 +25,7 @@ rkyv-support = ["rkyv", "bytecheck"]
 # include async client dependencies
 client = [
   "syncwrap", "reqwest", "tokio", "tokio-util", "futures", "git2", "shellexpand", "elasticsearch",
-  "tokio-tar", "http", "gix", "gix-date", "async-trait"
+  "astral-tokio-tar", "http", "gix", "gix-date", "async-trait"
   ]
 
 # include sync client dependencies
@@ -134,7 +134,7 @@ once_cell = { version = "1.21.3", optional = true }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid", "time", "url"], optional = true }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 lettre = { version = "0.11", features = ["tokio1", "tokio1-rustls-tls", "builder", "smtp-transport"], default-features = false, optional = true }
-thorium-derive = { path = "../thorium-derive", version = "1.3.0", optional = true}
+thorium-derive = { path = "../thorium-derive", version = "1.3.1", optional = true}
 percent-encoding = { version = "2.3.1", optional = true }
 dashmap = { version = "6.1", optional = true }
 
@@ -150,7 +150,7 @@ git2 = { version = "0.20", optional = true }
 gix = { version = "0.72", optional = true }
 gix-date = { version = "0.10", optional = true }
 shellexpand = { version = "3", optional = true }
-tokio-tar = { version = "0.3", optional = true }
+astral-tokio-tar = { version = "0.5.6", optional = true }
 
 # tracing dependencies
 tracing = { version = "0.1", optional = true }
@@ -187,3 +187,6 @@ async_once = "0.2"
 # udeps might think this is unused but its used by our doc tests
 tokio-test = "0.4"
 serial_test = "3"
+
+[lib]
+name = "thorium"

--- a/api/tests/files.rs
+++ b/api/tests/files.rs
@@ -895,7 +895,7 @@ async fn create_hidden_result() -> Result<(), thorium::Error> {
         OutputDisplayType::Hidden,
     )
     .tool_version(ImageVersion::SemVer(
-        semver::Version::parse("1.3.0-rc").unwrap(),
+        semver::Version::parse("1.3.1-rc").unwrap(),
     ));
     // send this result to the API
     client.files.create_result(output_req).await?;

--- a/event-handler/Cargo.toml
+++ b/event-handler/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "trace"] }
+thorium-api = {version= "1.3.1", path="../api", default-features = false, features = ["client", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = { version= "1.3.0", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
+thorium-api = { version= "1.3.1", path="../api", default-features = false, features = ["scylla-utils", "client", "k8s"] }
 reqwest = { version = "0.12", features = ["json"]}
 serde = "1.0"
 serde_json = "1.0"

--- a/reactor/Cargo.toml
+++ b/reactor/Cargo.toml
@@ -36,11 +36,11 @@ cfg-if = "1.0.0"
 
 # enable cgroups support for linux
 [target.'cfg(target_os = "linux")'.dependencies]
-thorium = { version= "1.3.0", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
+thorium-api = { version= "1.3.1", path="../api", default-features = false, features = ["client", "cgroups", "crossbeam-err", "trace", "rustix"]}
 cgroups-rs = "0.3"
 # enable support for kvm based jobs
 virt = { version = "0.4", optional = true }
 
 # disable cgroups support when on windows or macos
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-thorium = { version= "1.3.0", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}
+thorium-api = { version= "1.3.1", path="../api", default-features = false, features = ["client", "crossbeam-err", "trace"]}

--- a/scaler/Cargo.toml
+++ b/scaler/Cargo.toml
@@ -14,7 +14,7 @@ test-utilities = []
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
+thorium-api = {version= "1.3.1", path="../api", default-features = false, features = ["client", "k8s", "trace"] }
 reqwest = { version = "0.12", features = ["json"]}
 tokio = { version = "1.45", features = ["full"] }
 async-trait = "0.1"
@@ -43,5 +43,5 @@ hashbrown = "0.15"
 
 [dev-dependencies]
 thorium-scaler = { path = ".", features = ["test-utilities"]}
-thorium = {version= "1.3.0", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
+thorium-api = {version= "1.3.1", path="../api", default-features = false, features = ["client", "k8s", "trace", "test-utilities"] }
 serial_test = "3"

--- a/search-streamer/Cargo.toml
+++ b/search-streamer/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thorium-api = { path = "../api", version = "1.3.1", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.45", features = ["full"] }
-thorium = { version = "1.3.0", path = "../api", default-features=false, features = ["client", "kanal-err", "trace", "scylla-utils"]}
 chrono = { version = "=0.4.38", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/thoradm/Cargo.toml
+++ b/thoradm/Cargo.toml
@@ -12,7 +12,7 @@ vendored-openssl = ["openssl/vendored"]
 
 
 [dependencies]
-thorium = { version= "1.3.0", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
+thorium-api = { version= "1.3.1", path="../api", default-features = false, features = ["scylla-utils", "rkyv-support", "client"] }
 tokio = { version = "1.45", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 scylla = { version = "1.2", features = ["chrono-04"] }

--- a/thorctl/Cargo.toml
+++ b/thorctl/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thorium-api = { path = "../api", version = "1.3.1", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
 clap = { version = "4", features = ["derive", "wrap_help", "string"] }
 tokio = { version = "1.45", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
@@ -15,7 +16,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
 serde_derive = "1.0"
-thorium = { version = "1.3.0", path = "../api", default-features=false, features = ["client", "kanal-err", "dialoguer-err"]}
 colored = "3"
 owo-colors = "4"
 http = "1.3"


### PR DESCRIPTION
Previously Thorium used tokio-tar which was found to improperly handle tar unpacking resulting in CVE-2025-62518. Thorium now uses a different tar dependency which does not have this issue.
