### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cisagov/thorium)
+
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./api/docs/src/static_resources/logo_dark.svg">


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cisagov/thorium) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.