### PR TITLE
feat(mcp): Add documentation browsing and search tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6909,7 +6909,7 @@ dependencies = [
 
 [[package]]
 name = "thoradm"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6949,7 +6949,7 @@ dependencies = [
 
 [[package]]
 name = "thorctl"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "async-walkdir",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-agent"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "async-walkdir",
@@ -7030,7 +7030,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-api"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -7113,6 +7113,7 @@ dependencies = [
  "sha2",
  "shellexpand",
  "strum",
+ "tempfile",
  "thorium-derive",
  "tokio",
  "tokio-stream",
@@ -7135,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-derive"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -7145,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-event-handler"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "clap",
@@ -7160,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-operator"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
@@ -7189,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-reactor"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -7214,7 +7215,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-scaler"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7247,7 +7248,7 @@ dependencies = [
 
 [[package]]
 name = "thorium-search-streamer"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "bytesize",
@@ -7284,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "thorpy-stubs"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7097,6 +7097,7 @@ dependencies = [
  "argon2",
  "async-recursion",
  "async-trait",
+ "async-walkdir",
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-smithy-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5172,6 +5187,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,6 +5334,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -5485,6 +5525,15 @@ name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -6068,6 +6117,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -7092,6 +7153,7 @@ dependencies = [
  "opentelemetry-semantic-conventions 0.30.0",
  "opentelemetry_sdk 0.30.0",
  "percent-encoding",
+ "proptest",
  "pyo3",
  "rand 0.9.2",
  "redis 0.32.7",
@@ -7787,6 +7849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8018,6 +8086,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ADD ./ui/dist ui
 # copy ther user and developer docs in
 ADD ./api/docs/book docs/user
 ADD ./target/doc docs/dev
+# copy raw documentation markdown source for MCP documentation tools
+ADD ./api/docs/src docs/src
 # copy our binaries in
 ADD ./target/x86_64-unknown-linux-musl/release/thorctl binaries/linux/x86-64/thorctl
 ADD ./target/x86_64-unknown-linux-musl/release/thorium-agent binaries/linux/x86-64/thorium-agent

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -205,3 +205,4 @@ rand = { version = "0.9.1", features = ["alloc", "small_rng"] }
 # udeps might think this is unused but its used by our doc tests
 tokio-test = "0.4"
 serial_test = "3"
+tempfile = "3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -206,3 +206,4 @@ rand = { version = "0.9.1", features = ["alloc", "small_rng"] }
 tokio-test = "0.4"
 serial_test = "3"
 tempfile = "3"
+proptest = "1"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,7 +18,8 @@ api = [
   "scylla", "ldap3", "itertools", "sha-1", "sha2", "md-5", "data-encoding", "anyhow", "elasticsearch", "zip", "async-trait",
   "axum", "http", "tower", "axum-macros", "tower-http", "tokio-stream", "generic-array", "futures-util", "tokio-util", "serde_qs",
   "aws-sdk-s3", "aws-types", "aws-smithy-http", "aws-credential-types", "scylla-utils", "http-body", "axum-extra", "once_cell", "utoipa",
-  "utoipa-swagger-ui", "lettre", "headers", "percent-encoding", "dashmap", "mime", "rmcp"
+  "utoipa-swagger-ui", "lettre", "headers", "percent-encoding", "dashmap", "mime", "rmcp",
+  "async-walkdir"
   ]
 
 # include scylla utility functions
@@ -122,6 +123,7 @@ headers = { version = "0.4", optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["full"], optional = true }
 async-recursion = { version = "1", optional = true }
+async-walkdir = { version = "2", optional = true }
 rand = { version = "0.9.1", features = ["alloc"], optional = true }
 colored = { version = "3", optional = true }
 scylla = { version = "1.2", features = ["chrono-04"], optional = true }

--- a/api/src/conf.rs
+++ b/api/src/conf.rs
@@ -2045,6 +2045,11 @@ fn default_binaries_path() -> PathBuf {
     PathBuf::from("binaries")
 }
 
+/// Helps serde default the path to our raw documentation source markdown
+fn default_docs_src_path() -> PathBuf {
+    PathBuf::from("docs/src")
+}
+
 /// Helps serde default the path resource not found
 fn default_not_found_path() -> PathBuf {
     PathBuf::from("docs/user/static_resources/mascot.png")
@@ -2062,6 +2067,9 @@ pub struct Assets {
     /// The path to serve Thorium binaries from
     #[serde(default = "default_binaries_path")]
     pub binaries: PathBuf,
+    /// The path to our raw documentation source markdown for MCP tools
+    #[serde(default = "default_docs_src_path")]
+    pub docs_src: PathBuf,
     /// The path to the 404 page to serve on docs/binary serving 404s
     #[serde(default = "default_not_found_path")]
     pub not_found: PathBuf,
@@ -2074,6 +2082,7 @@ impl Default for Assets {
             user_docs: default_user_docs_path(),
             dev_docs: default_dev_docs_path(),
             binaries: default_binaries_path(),
+            docs_src: default_docs_src_path(),
             not_found: default_not_found_path(),
         }
     }

--- a/api/src/routes/mcp/docs.rs
+++ b/api/src/routes/mcp/docs.rs
@@ -1,0 +1,645 @@
+//! The documentation related tools for the Thorium MCP server
+
+use std::path::Path;
+
+use rmcp::ErrorData;
+use rmcp::handler::server::tool::Extension as RmcpExtension;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router};
+use schemars::JsonSchema;
+use tracing::instrument;
+
+use super::{McpConfig, ThoriumMCP};
+
+/// A single entry from the documentation table of contents
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct TocEntry {
+    /// The display title of this documentation page
+    pub title: String,
+    /// The relative path to this documentation page
+    pub path: String,
+    /// The nesting depth of this entry (0 = top level)
+    pub depth: usize,
+}
+
+/// The params needed to get a specific documentation page
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DocPage {
+    /// The relative path to the documentation page (e.g. "concepts/files.md")
+    pub path: String,
+}
+
+/// The params needed to search the documentation
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SearchDocs {
+    /// The search query to find in the documentation
+    pub query: String,
+}
+
+/// A single search result with context snippets
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SearchResult {
+    /// The relative path to the matching documentation page
+    pub path: String,
+    /// The title of the matching page
+    pub title: String,
+    /// The number of matches found in this page
+    pub match_count: usize,
+    /// Context snippets around the matches
+    pub snippets: Vec<String>,
+}
+
+/// An empty parameter set for tools that take no arguments
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct Empty {}
+
+/// Parse the SUMMARY.md file into a list of table of contents entries
+///
+/// # Arguments
+///
+/// * `content` - The raw SUMMARY.md content
+fn parse_summary(content: &str) -> Vec<TocEntry> {
+    let mut entries = Vec::new();
+    for line in content.lines() {
+        // skip lines that don't contain a markdown link
+        let Some(bracket_start) = line.find('[') else {
+            continue;
+        };
+        let Some(bracket_end) = line[bracket_start..].find(']') else {
+            continue;
+        };
+        let bracket_end = bracket_start + bracket_end;
+        let Some(paren_start) = line[bracket_end..].find('(') else {
+            continue;
+        };
+        let paren_start = bracket_end + paren_start;
+        let Some(paren_end) = line[paren_start..].find(')') else {
+            continue;
+        };
+        let paren_end = paren_start + paren_end;
+
+        let title = line[bracket_start + 1..bracket_end].to_string();
+        let raw_path = line[paren_start + 1..paren_end].to_string();
+        // strip the leading ./ if present
+        let path = raw_path.strip_prefix("./").unwrap_or(&raw_path).to_string();
+
+        // calculate depth from leading whitespace (4 spaces per level)
+        let leading_spaces = line.len() - line.trim_start().len();
+        let depth = leading_spaces / 4;
+
+        entries.push(TocEntry {
+            title,
+            path,
+            depth,
+        });
+    }
+    entries
+}
+
+/// Validate a documentation path to prevent directory traversal
+///
+/// # Arguments
+///
+/// * `docs_path` - The base documentation directory
+/// * `requested` - The requested relative path
+fn validate_doc_path(docs_path: &Path, requested: &str) -> Result<std::path::PathBuf, ErrorData> {
+    // reject paths with directory traversal components
+    if requested.contains("..") {
+        return Err(ErrorData {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: "Invalid path: directory traversal is not allowed".into(),
+            data: None,
+        });
+    }
+
+    let full_path = docs_path.join(requested);
+
+    // canonicalize both paths to resolve any symlinks and verify containment
+    let canonical_base = docs_path.canonicalize().map_err(|e| ErrorData {
+        code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+        message: format!("Failed to resolve docs directory: {e}").into(),
+        data: None,
+    })?;
+    let canonical_target = full_path.canonicalize().map_err(|_| ErrorData {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: format!("Documentation page not found: {requested}").into(),
+        data: None,
+    })?;
+
+    if !canonical_target.starts_with(&canonical_base) {
+        return Err(ErrorData {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: "Invalid path: outside documentation directory".into(),
+            data: None,
+        });
+    }
+
+    Ok(canonical_target)
+}
+
+/// Recursively collect all markdown file paths under a directory
+///
+/// # Arguments
+///
+/// * `dir` - The directory to walk
+/// * `paths` - The output vector to collect paths into
+fn collect_md_files(dir: &Path, paths: &mut Vec<std::path::PathBuf>) -> Result<(), std::io::Error> {
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_md_files(&path, paths)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            paths.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Extract the page title from markdown content (the first # heading)
+///
+/// # Arguments
+///
+/// * `content` - The raw markdown content
+fn extract_title(content: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(title) = trimmed.strip_prefix("# ") {
+            return title.to_string();
+        }
+    }
+    "Untitled".to_string()
+}
+
+/// Extract context snippets around search matches
+///
+/// # Arguments
+///
+/// * `content` - The raw markdown content
+/// * `query_lower` - The lowercased search query
+/// * `max_snippets` - Maximum number of snippets to return
+fn extract_snippets(content: &str, query_lower: &str, max_snippets: usize) -> Vec<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut snippets = Vec::new();
+    let mut last_snippet_line: Option<usize> = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        if snippets.len() >= max_snippets {
+            break;
+        }
+        if line.to_lowercase().contains(query_lower) {
+            // skip if too close to the previous snippet
+            if let Some(last) = last_snippet_line {
+                if i <= last + 2 {
+                    continue;
+                }
+            }
+            // grab the matching line with one line of context on each side
+            let start = i.saturating_sub(1);
+            let end = (i + 2).min(lines.len());
+            let snippet: String = lines[start..end].join("\n");
+            snippets.push(snippet);
+            last_snippet_line = Some(i);
+        }
+    }
+    snippets
+}
+
+#[tool_router(router = docs_router, vis = "pub")]
+impl ThoriumMCP {
+    /// Get the table of contents for the Thorium documentation
+    ///
+    /// # Arguments
+    ///
+    /// * `parts` - The request parts required to validate authorization
+    #[tool(
+        name = "get_docs_toc",
+        description = "Get the table of contents for the Thorium documentation. Returns a structured list of all documentation pages with their titles, paths, and nesting depth. Call this first to understand what documentation is available."
+    )]
+    #[instrument(name = "ThoriumMCP::get_docs_toc", skip(self, _params, parts), err(Debug))]
+    pub async fn get_docs_toc(
+        &self,
+        Parameters(_params): Parameters<Empty>,
+        RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // validate authorization
+        McpConfig::grab_token(&parts)?;
+        // read SUMMARY.md
+        let summary_path = self.conf.docs_path.join("SUMMARY.md");
+        let content =
+            tokio::fs::read_to_string(&summary_path)
+                .await
+                .map_err(|e| ErrorData {
+                    code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    message: format!("Failed to read documentation index: {e}").into(),
+                    data: None,
+                })?;
+        // parse the summary into structured entries
+        let entries = parse_summary(&content);
+        // serialize our entries
+        let serialized = serde_json::to_value(&entries).unwrap();
+        // build our result
+        let result = CallToolResult {
+            content: vec![Content::json(&entries)?],
+            structured_content: Some(serialized),
+            is_error: Some(false),
+            meta: None,
+        };
+        Ok(result)
+    }
+
+    /// Get the content of a specific documentation page
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - The parameters containing the page path
+    /// * `parts` - The request parts required to validate authorization
+    #[tool(
+        name = "get_doc_page",
+        description = "Get the content of a specific Thorium documentation page by its relative path (e.g. 'concepts/files.md'). Use get_docs_toc first to discover available page paths."
+    )]
+    #[instrument(name = "ThoriumMCP::get_doc_page", skip(self, parts), err(Debug))]
+    pub async fn get_doc_page(
+        &self,
+        Parameters(DocPage { path }): Parameters<DocPage>,
+        RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // validate authorization
+        McpConfig::grab_token(&parts)?;
+        // validate and resolve the path
+        let full_path = validate_doc_path(&self.conf.docs_path, &path)?;
+        // read the file
+        let content =
+            tokio::fs::read_to_string(&full_path)
+                .await
+                .map_err(|e| ErrorData {
+                    code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    message: format!("Failed to read documentation page: {e}").into(),
+                    data: None,
+                })?;
+        // build our result with the raw markdown as text content
+        let serialized = serde_json::to_value(&serde_json::json!({
+            "path": path,
+            "content": content,
+        }))
+        .unwrap();
+        let result = CallToolResult {
+            content: vec![Content::text(content)],
+            structured_content: Some(serialized),
+            is_error: Some(false),
+            meta: None,
+        };
+        Ok(result)
+    }
+
+    /// Search across all Thorium documentation pages
+    ///
+    /// # Arguments
+    ///
+    /// * `parameters` - The parameters containing the search query
+    /// * `parts` - The request parts required to validate authorization
+    #[tool(
+        name = "search_docs",
+        description = "Search across all Thorium documentation pages for a query string. Returns matching pages with titles, match counts, and context snippets. Use this to find documentation about a specific topic."
+    )]
+    #[instrument(name = "ThoriumMCP::search_docs", skip(self, parts), err(Debug))]
+    pub async fn search_docs(
+        &self,
+        Parameters(SearchDocs { query }): Parameters<SearchDocs>,
+        RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // validate authorization
+        McpConfig::grab_token(&parts)?;
+        // validate query is not empty
+        if query.trim().is_empty() {
+            return Err(ErrorData {
+                code: rmcp::model::ErrorCode::INVALID_PARAMS,
+                message: "Search query must not be empty".into(),
+                data: None,
+            });
+        }
+        let query_lower = query.to_lowercase();
+        // collect all markdown files
+        let mut md_files = Vec::new();
+        collect_md_files(&self.conf.docs_path, &mut md_files).map_err(
+            |e| ErrorData {
+                code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+                message: format!("Failed to read documentation directory: {e}").into(),
+                data: None,
+            },
+        )?;
+        // search each file
+        let mut results: Vec<SearchResult> = Vec::new();
+        for file_path in &md_files {
+            let content = match tokio::fs::read_to_string(file_path).await {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let content_lower = content.to_lowercase();
+            let match_count = content_lower.matches(&query_lower).count();
+            if match_count == 0 {
+                continue;
+            }
+            // get the relative path from the docs root
+            let rel_path = file_path
+                .strip_prefix(&self.conf.docs_path)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .to_string();
+            let title = extract_title(&content);
+            let snippets = extract_snippets(&content, &query_lower, 3);
+            results.push(SearchResult {
+                path: rel_path,
+                title,
+                match_count,
+                snippets,
+            });
+        }
+        // sort by match count descending and limit to top 10
+        results.sort_by(|a, b| b.match_count.cmp(&a.match_count));
+        results.truncate(10);
+        // serialize our results
+        let serialized = serde_json::to_value(&results).unwrap();
+        // build our result
+        let result = CallToolResult {
+            content: vec![Content::json(&results)?],
+            structured_content: Some(serialized),
+            is_error: Some(false),
+            meta: None,
+        };
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    // ── parse_summary ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_summary_basic() {
+        let content = "\
+# Summary
+
+- [Intro](./intro.md)
+- [Getting Started](./getting_started/getting_started.md)
+    - [Registration](./getting_started/registration.md)
+    - [Login](./getting_started/login.md)
+        - [Advanced Login](./getting_started/advanced_login.md)
+";
+        let entries = parse_summary(content);
+        assert_eq!(entries.len(), 5);
+
+        assert_eq!(entries[0].title, "Intro");
+        assert_eq!(entries[0].path, "intro.md");
+        assert_eq!(entries[0].depth, 0);
+
+        assert_eq!(entries[1].title, "Getting Started");
+        assert_eq!(entries[1].path, "getting_started/getting_started.md");
+        assert_eq!(entries[1].depth, 0);
+
+        assert_eq!(entries[2].title, "Registration");
+        assert_eq!(entries[2].path, "getting_started/registration.md");
+        assert_eq!(entries[2].depth, 1);
+
+        assert_eq!(entries[3].title, "Login");
+        assert_eq!(entries[3].depth, 1);
+
+        assert_eq!(entries[4].title, "Advanced Login");
+        assert_eq!(entries[4].depth, 2);
+    }
+
+    #[test]
+    fn parse_summary_strips_dot_slash_prefix() {
+        let content = "- [Page](./some/path.md)\n- [Other](other/path.md)\n";
+        let entries = parse_summary(content);
+        assert_eq!(entries[0].path, "some/path.md");
+        assert_eq!(entries[1].path, "other/path.md");
+    }
+
+    #[test]
+    fn parse_summary_skips_non_link_lines() {
+        let content = "\
+# Summary
+
+Some random text here.
+
+- [Actual Link](./page.md)
+
+Another non-link line.
+";
+        let entries = parse_summary(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Actual Link");
+    }
+
+    #[test]
+    fn parse_summary_empty_input() {
+        let entries = parse_summary("");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_summary_against_real_docs() {
+        let summary_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("docs")
+            .join("src")
+            .join("SUMMARY.md");
+        if !summary_path.exists() {
+            return; // skip if docs aren't available
+        }
+        let content = fs::read_to_string(&summary_path).unwrap();
+        let entries = parse_summary(&content);
+        // the real SUMMARY.md has many entries — just verify it parsed something
+        assert!(entries.len() > 10, "Expected many TOC entries, got {}", entries.len());
+        // first entry should be Intro
+        assert_eq!(entries[0].title, "Intro");
+        assert_eq!(entries[0].path, "intro.md");
+        assert_eq!(entries[0].depth, 0);
+    }
+
+    // ── validate_doc_path ──────────────────────────────────────────
+
+    #[test]
+    fn validate_doc_path_rejects_traversal() {
+        let docs = PathBuf::from("/tmp");
+        let err = validate_doc_path(&docs, "../etc/passwd").unwrap_err();
+        assert!(err.message.contains("directory traversal"));
+    }
+
+    #[test]
+    fn validate_doc_path_rejects_hidden_traversal() {
+        let docs = PathBuf::from("/tmp");
+        let err = validate_doc_path(&docs, "foo/../../etc/passwd").unwrap_err();
+        assert!(err.message.contains("directory traversal"));
+    }
+
+    #[test]
+    fn validate_doc_path_accepts_valid_path() {
+        // create a temp file to validate against
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.md");
+        fs::write(&file_path, "# Test").unwrap();
+
+        let result = validate_doc_path(dir.path(), "test.md");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), file_path.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn validate_doc_path_rejects_nonexistent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = validate_doc_path(dir.path(), "nonexistent.md").unwrap_err();
+        assert!(err.message.contains("not found"));
+    }
+
+    // ── collect_md_files ───────────────────────────────────────────
+
+    #[test]
+    fn collect_md_files_finds_markdown() {
+        let dir = tempfile::tempdir().unwrap();
+        // create some files
+        fs::write(dir.path().join("page.md"), "# Page").unwrap();
+        fs::write(dir.path().join("readme.txt"), "not markdown").unwrap();
+        fs::write(dir.path().join("image.png"), "not markdown").unwrap();
+        // create a subdirectory with another md file
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("nested.md"), "# Nested").unwrap();
+
+        let mut paths = Vec::new();
+        collect_md_files(dir.path(), &mut paths).unwrap();
+
+        assert_eq!(paths.len(), 2);
+        let names: Vec<String> = paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"page.md".to_string()));
+        assert!(names.contains(&"nested.md".to_string()));
+    }
+
+    #[test]
+    fn collect_md_files_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut paths = Vec::new();
+        collect_md_files(dir.path(), &mut paths).unwrap();
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn collect_md_files_against_real_docs() {
+        let docs_src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("docs")
+            .join("src");
+        if !docs_src.exists() {
+            return; // skip if docs aren't available
+        }
+        let mut paths = Vec::new();
+        collect_md_files(&docs_src, &mut paths).unwrap();
+        // the real docs have 80+ markdown files
+        assert!(paths.len() > 50, "Expected many md files, got {}", paths.len());
+        // all should be .md files
+        assert!(paths.iter().all(|p| p.extension().unwrap() == "md"));
+    }
+
+    // ── extract_title ──────────────────────────────────────────────
+
+    #[test]
+    fn extract_title_finds_h1() {
+        let content = "Some preamble\n# My Title\n\nBody text here.";
+        assert_eq!(extract_title(content), "My Title");
+    }
+
+    #[test]
+    fn extract_title_returns_first_h1() {
+        let content = "# First Title\n## Subtitle\n# Second Title";
+        assert_eq!(extract_title(content), "First Title");
+    }
+
+    #[test]
+    fn extract_title_ignores_h2_and_deeper() {
+        let content = "## Not A Title\n### Also Not\nNo headings here.";
+        assert_eq!(extract_title(content), "Untitled");
+    }
+
+    #[test]
+    fn extract_title_handles_empty_content() {
+        assert_eq!(extract_title(""), "Untitled");
+    }
+
+    #[test]
+    fn extract_title_handles_leading_whitespace() {
+        let content = "  # Indented Title\n";
+        assert_eq!(extract_title(content), "Indented Title");
+    }
+
+    // ── extract_snippets ───────────────────────────────────────────
+
+    #[test]
+    fn extract_snippets_basic() {
+        let content = "line 0\nline 1\nfoo bar baz\nline 3\nline 4\n";
+        let snippets = extract_snippets(content, "foo", 3);
+        assert_eq!(snippets.len(), 1);
+        // should include the line before, the match line, and the line after
+        assert!(snippets[0].contains("line 1"));
+        assert!(snippets[0].contains("foo bar baz"));
+        assert!(snippets[0].contains("line 3"));
+    }
+
+    #[test]
+    fn extract_snippets_case_insensitive() {
+        let content = "Hello World\nFOO BAR\nGoodbye";
+        let snippets = extract_snippets(content, "foo", 3);
+        assert_eq!(snippets.len(), 1);
+        assert!(snippets[0].contains("FOO BAR"));
+    }
+
+    #[test]
+    fn extract_snippets_respects_max() {
+        let content = "match1\n\n\n\nmatch2\n\n\n\nmatch3\n\n\n\nmatch4\n";
+        let snippets = extract_snippets(content, "match", 2);
+        assert_eq!(snippets.len(), 2);
+    }
+
+    #[test]
+    fn extract_snippets_skips_adjacent_matches() {
+        // matches on consecutive lines should be collapsed into one snippet
+        let content = "foo line 1\nfoo line 2\nfoo line 3\n\n\n\nfoo line 7\n";
+        let snippets = extract_snippets(content, "foo", 3);
+        // first match at line 0 grabs context [0..2], so lines 1-2 are within +2
+        // line 7 match (index 6) is far enough away
+        assert_eq!(snippets.len(), 2);
+    }
+
+    #[test]
+    fn extract_snippets_match_at_first_line() {
+        let content = "match here\nline 1\nline 2\n";
+        let snippets = extract_snippets(content, "match", 3);
+        assert_eq!(snippets.len(), 1);
+        // should not crash on saturating_sub(1) when match is at index 0
+        assert!(snippets[0].contains("match here"));
+        assert!(snippets[0].contains("line 1"));
+    }
+
+    #[test]
+    fn extract_snippets_match_at_last_line() {
+        let content = "line 0\nline 1\nmatch here";
+        let snippets = extract_snippets(content, "match", 3);
+        assert_eq!(snippets.len(), 1);
+        assert!(snippets[0].contains("line 1"));
+        assert!(snippets[0].contains("match here"));
+    }
+
+    #[test]
+    fn extract_snippets_no_matches() {
+        let content = "nothing relevant here\nat all\n";
+        let snippets = extract_snippets(content, "nonexistent", 3);
+        assert!(snippets.is_empty());
+    }
+}

--- a/api/src/routes/mcp/docs.rs
+++ b/api/src/routes/mcp/docs.rs
@@ -50,10 +50,6 @@ pub struct SearchResult {
     pub snippets: Vec<String>,
 }
 
-/// An empty parameter set for tools that take no arguments
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Empty {}
-
 /// Parse the SUMMARY.md file into a list of table of contents entries
 ///
 /// # Arguments
@@ -218,10 +214,9 @@ impl ThoriumMCP {
         name = "get_docs_toc",
         description = "Get the table of contents for the Thorium documentation. Returns a structured list of all documentation pages with their titles, paths, and nesting depth. Call this first to understand what documentation is available."
     )]
-    #[instrument(name = "ThoriumMCP::get_docs_toc", skip(self, _params, parts), err(Debug))]
+    #[instrument(name = "ThoriumMCP::get_docs_toc", skip(self, parts), err(Debug))]
     pub async fn get_docs_toc(
         &self,
-        Parameters(_params): Parameters<Empty>,
         RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
         // validate authorization

--- a/api/src/routes/mcp/docs.rs
+++ b/api/src/routes/mcp/docs.rs
@@ -22,6 +22,8 @@
 
 use std::path::Path;
 
+use async_walkdir::WalkDir;
+use futures::stream::StreamExt;
 use rmcp::ErrorData;
 use rmcp::handler::server::tool::Extension as RmcpExtension;
 use rmcp::handler::server::wrapper::Parameters;
@@ -64,6 +66,24 @@ pub struct DocPage {
 pub struct SearchDocs {
     /// The search query to find in the documentation.
     pub query: String,
+    /// Maximum number of results to return (default: 10).
+    #[serde(default)]
+    pub max_results: Option<usize>,
+    /// Maximum number of context snippets per result (default: 3).
+    #[serde(default)]
+    pub max_snippets: Option<usize>,
+    /// Number of context lines above and below each match (default: 1).
+    #[serde(default)]
+    pub context_lines: Option<usize>,
+}
+
+/// A context snippet around a search match with its location in the source file.
+#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Snippet {
+    /// The text content of the snippet with surrounding context lines.
+    pub text: String,
+    /// The 1-based line number where the match occurs in the source file.
+    pub line_offset: usize,
 }
 
 /// A single search result with context snippets.
@@ -76,15 +96,15 @@ pub struct SearchResult {
     /// The number of matches found in this page.
     pub match_count: usize,
     /// Context snippets around the matches.
-    pub snippets: Vec<String>,
+    pub snippets: Vec<Snippet>,
 }
 
-/// Parse the SUMMARY.md file into a list of table of contents entries.
+/// Parse TOC entries from raw SUMMARY.md content.
 ///
 /// Each line in SUMMARY.md is formatted as `"    - [Title](./path.md)"`
 /// where leading whitespace indicates nesting depth (4 spaces per level).
 /// Lines that don't contain a valid markdown link are skipped.
-fn parse_summary(content: &str) -> Vec<TocEntry> {
+fn parse_toc_entries(content: &str) -> Vec<TocEntry> {
     content
         .lines()
         .filter_map(|line| {
@@ -112,6 +132,25 @@ fn parse_summary(content: &str) -> Vec<TocEntry> {
             })
         })
         .collect()
+}
+
+/// Read and parse the SUMMARY.md table of contents from the documentation root.
+///
+/// Combines file I/O with [`parse_toc_entries`] so callers don't need to know
+/// about the `SUMMARY.md` convention.
+///
+/// # Errors
+///
+/// Returns `ErrorData` with `INTERNAL_ERROR` if `SUMMARY.md` cannot be read.
+async fn parse_summary(docs_path: &Path) -> Result<Vec<TocEntry>, ErrorData> {
+    let content = tokio::fs::read_to_string(docs_path.join("SUMMARY.md"))
+        .await
+        .map_err(|e| ErrorData {
+            code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+            message: format!("Failed to read documentation index: {e}").into(),
+            data: None,
+        })?;
+    Ok(parse_toc_entries(&content))
 }
 
 /// Validate a documentation path to prevent directory traversal.
@@ -163,35 +202,43 @@ fn validate_doc_path(docs_path: &Path, requested: &str) -> Result<std::path::Pat
     Ok(canonical_target)
 }
 
-/// Recursively collect all markdown file paths under a directory.
+/// Collect all markdown file paths under a directory using async traversal.
+///
+/// Uses [`async_walkdir::WalkDir`] to avoid blocking the async runtime on
+/// large directory trees.
 ///
 /// # Errors
 ///
 /// Returns `std::io::Error` if the directory cannot be read or any entry
 /// within it cannot be inspected.
-fn collect_md_files(dir: &Path) -> Result<Vec<std::path::PathBuf>, std::io::Error> {
-    Ok(std::fs::read_dir(dir)?
-        .map(|entry| {
-            let path = entry?.path();
-            if path.is_dir() {
-                collect_md_files(&path)
-            } else {
-                Ok(vec![path])
-            }
-        })
-        .collect::<Result<Vec<Vec<_>>, _>>()?
-        .into_iter()
-        .flatten()
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
-        .collect())
+async fn collect_md_files(dir: &Path) -> Result<Vec<std::path::PathBuf>, std::io::Error> {
+    let mut paths = Vec::new();
+    let mut walker = WalkDir::new(dir);
+    while let Some(entry) = walker.next().await {
+        let entry = entry.map_err(std::io::Error::from)?;
+        let path = entry.path();
+        if !path.is_dir() && path.extension().and_then(|e| e.to_str()) == Some("md") {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
 }
 
 /// Extract the page title from markdown content (the first `# ` heading).
-fn extract_title(content: &str) -> String {
+///
+/// Falls back to the file stem (filename without extension) if a path is
+/// provided and no `# ` heading is found. Returns `"Untitled"` only when
+/// both the heading and the path are absent.
+fn extract_title(content: &str, path: Option<&Path>) -> String {
     content
         .lines()
         .find_map(|line| line.trim().strip_prefix("# ").map(String::from))
-        .unwrap_or_else(|| "Untitled".to_string())
+        .unwrap_or_else(|| {
+            path.and_then(|p| p.file_stem())
+                .and_then(|s| s.to_str())
+                .map(String::from)
+                .unwrap_or_else(|| "Untitled".to_string())
+        })
 }
 
 /// Extract context snippets around search matches.
@@ -204,7 +251,7 @@ fn extract_snippets(
     query_lower: &str,
     max_snippets: usize,
     context_lines: usize,
-) -> Vec<String> {
+) -> Vec<Snippet> {
     let lines: Vec<&str> = content.lines().collect();
     let mut snippets = Vec::new();
     let mut last_snippet_line: Option<usize> = None;
@@ -223,8 +270,11 @@ fn extract_snippets(
             // grab the matching line with context on each side
             let start = i.saturating_sub(context_lines);
             let end = (i + context_lines + 1).min(lines.len());
-            let snippet: String = lines[start..end].join("\n");
-            snippets.push(snippet);
+            let text: String = lines[start..end].join("\n");
+            snippets.push(Snippet {
+                text,
+                line_offset: i + 1, // 1-based line number
+            });
             last_snippet_line = Some(i);
         }
     }
@@ -251,17 +301,7 @@ impl ThoriumMCP {
     ) -> Result<CallToolResult, ErrorData> {
         McpConfig::grab_token(&parts)?;
 
-        let summary_path = self.conf.docs_path.join("SUMMARY.md");
-        let content =
-            tokio::fs::read_to_string(&summary_path)
-                .await
-                .map_err(|e| ErrorData {
-                    code: rmcp::model::ErrorCode::INTERNAL_ERROR,
-                    message: format!("Failed to read documentation index: {e}").into(),
-                    data: None,
-                })?;
-
-        let entries = parse_summary(&content);
+        let entries = parse_summary(&self.conf.docs_path).await?;
         let serialized = serde_json::to_value(&entries).unwrap();
 
         Ok(CallToolResult {
@@ -332,7 +372,12 @@ impl ThoriumMCP {
     #[instrument(name = "ThoriumMCP::search_docs", skip(self, parts), err(Debug))]
     pub async fn search_docs(
         &self,
-        Parameters(SearchDocs { query }): Parameters<SearchDocs>,
+        Parameters(SearchDocs {
+            query,
+            max_results,
+            max_snippets,
+            context_lines,
+        }): Parameters<SearchDocs>,
         RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
         McpConfig::grab_token(&parts)?;
@@ -345,57 +390,60 @@ impl ThoriumMCP {
             });
         }
 
+        let max_results = max_results.unwrap_or(MAX_SEARCH_RESULTS);
+        let max_snippets = max_snippets.unwrap_or(MAX_SNIPPETS_PER_PAGE);
+        let context_lines = context_lines.unwrap_or(SNIPPET_CONTEXT_LINES);
         let query_lower = query.to_lowercase();
 
         let md_files =
-            collect_md_files(&self.conf.docs_path).map_err(|e| ErrorData {
-                code: rmcp::model::ErrorCode::INTERNAL_ERROR,
-                message: format!("Failed to read documentation directory: {e}").into(),
-                data: None,
-            })?;
+            collect_md_files(&self.conf.docs_path)
+                .await
+                .map_err(|e| ErrorData {
+                    code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    message: format!("Failed to read documentation directory: {e}").into(),
+                    data: None,
+                })?;
 
-        let mut results: Vec<SearchResult> = md_files
-            .iter()
-            .filter_map(|file_path| {
-                let content = match std::fs::read_to_string(file_path) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        tracing::warn!(
-                            path = %file_path.display(),
-                            "Failed to read documentation file: {e}"
-                        );
-                        return None;
-                    }
-                };
-
-                let match_count =
-                    content.to_lowercase().matches(&query_lower).count();
-                if match_count == 0 {
-                    return None;
+        let mut results: Vec<SearchResult> = Vec::new();
+        for file_path in &md_files {
+            let content = match tokio::fs::read_to_string(file_path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %file_path.display(),
+                        "Failed to read documentation file: {e}"
+                    );
+                    continue;
                 }
+            };
 
-                let rel_path = file_path
-                    .strip_prefix(&self.conf.docs_path)
-                    .unwrap_or(file_path)
-                    .to_string_lossy()
-                    .to_string();
+            let match_count =
+                content.to_lowercase().matches(&query_lower).count();
+            if match_count == 0 {
+                continue;
+            }
 
-                Some(SearchResult {
-                    title: extract_title(&content),
-                    snippets: extract_snippets(
-                        &content,
-                        &query_lower,
-                        MAX_SNIPPETS_PER_PAGE,
-                        SNIPPET_CONTEXT_LINES,
-                    ),
-                    path: rel_path,
-                    match_count,
-                })
-            })
-            .collect();
+            let rel_path = file_path
+                .strip_prefix(&self.conf.docs_path)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .to_string();
+
+            results.push(SearchResult {
+                title: extract_title(&content, Some(file_path)),
+                snippets: extract_snippets(
+                    &content,
+                    &query_lower,
+                    max_snippets,
+                    context_lines,
+                ),
+                path: rel_path,
+                match_count,
+            });
+        }
 
         results.sort_by(|a, b| b.match_count.cmp(&a.match_count));
-        results.truncate(MAX_SEARCH_RESULTS);
+        results.truncate(max_results);
 
         let serialized = serde_json::to_value(&results).unwrap();
 
@@ -429,7 +477,7 @@ mod tests {
     - [Login](./getting_started/login.md)
         - [Advanced Login](./getting_started/advanced_login.md)
 ";
-        let entries = parse_summary(content);
+        let entries = parse_toc_entries(content);
         assert_eq!(
             entries,
             vec![
@@ -471,7 +519,7 @@ mod tests {
         ) {
             let indent = " ".repeat(depth * 4);
             let line = format!("{indent}- [{title}](./{path})");
-            let entries = parse_summary(&line);
+            let entries = parse_toc_entries(&line);
             prop_assert_eq!(entries.len(), 1);
             prop_assert_eq!(&entries[0].title, &title);
             prop_assert_eq!(&entries[0].path, &path);
@@ -482,7 +530,7 @@ mod tests {
         fn parse_summary_skips_non_links(
             text in "[A-Za-z0-9 ]{1,50}",
         ) {
-            let entries = parse_summary(&text);
+            let entries = parse_toc_entries(&text);
             prop_assert!(entries.is_empty());
         }
     }
@@ -499,7 +547,7 @@ mod tests {
             summary_path.display()
         );
         let content = fs::read_to_string(&summary_path).unwrap();
-        let entries = parse_summary(&content);
+        let entries = parse_toc_entries(&content);
         assert!(
             entries.len() > 10,
             "Expected many TOC entries, got {}",
@@ -548,8 +596,8 @@ mod tests {
 
     // ── collect_md_files ───────────────────────────────────────────
 
-    #[test]
-    fn collect_md_files_finds_markdown() {
+    #[tokio::test]
+    async fn collect_md_files_finds_markdown() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("dragons.md"), "# Here Be Dragons").unwrap();
         fs::write(dir.path().join("treasure_map.txt"), "X marks the spot").unwrap();
@@ -558,7 +606,7 @@ mod tests {
         fs::create_dir(&sub).unwrap();
         fs::write(sub.join("boss_fight.md"), "# The Final Boss").unwrap();
 
-        let paths = collect_md_files(dir.path()).unwrap();
+        let paths = collect_md_files(dir.path()).await.unwrap();
         assert_eq!(paths.len(), 2);
         let names: Vec<String> = paths
             .iter()
@@ -568,15 +616,15 @@ mod tests {
         assert!(names.contains(&"boss_fight.md".to_string()));
     }
 
-    #[test]
-    fn collect_md_files_empty_dir() {
+    #[tokio::test]
+    async fn collect_md_files_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let paths = collect_md_files(dir.path()).unwrap();
+        let paths = collect_md_files(dir.path()).await.unwrap();
         assert!(paths.is_empty());
     }
 
-    #[test]
-    fn collect_md_files_against_real_docs() {
+    #[tokio::test]
+    async fn collect_md_files_against_real_docs() {
         let docs_src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("docs")
             .join("src");
@@ -585,7 +633,7 @@ mod tests {
             "Real docs not found at {}",
             docs_src.display()
         );
-        let paths = collect_md_files(&docs_src).unwrap();
+        let paths = collect_md_files(&docs_src).await.unwrap();
         assert!(
             paths.len() > 50,
             "Expected many md files, got {}",
@@ -602,7 +650,7 @@ mod tests {
             title in "[A-Za-z]{1,30}",
         ) {
             let content = format!("some preamble\n## Not This\n# {title}\nBody text.");
-            prop_assert_eq!(extract_title(&content), title);
+            prop_assert_eq!(extract_title(&content, None), title);
         }
 
         #[test]
@@ -610,8 +658,17 @@ mod tests {
             body in "[a-z ]{1,100}",
         ) {
             // body only contains lowercase letters and spaces, never "# "
-            prop_assert_eq!(extract_title(&body), "Untitled");
+            prop_assert_eq!(extract_title(&body, None), "Untitled");
         }
+    }
+
+    #[test]
+    fn extract_title_falls_back_to_filename() {
+        let path = Path::new("concepts/getting_started.md");
+        assert_eq!(
+            extract_title("no heading here", Some(path)),
+            "getting_started"
+        );
     }
 
     // ── extract_snippets ───────────────────────────────────────────
@@ -655,9 +712,9 @@ mod tests {
                 extract_snippets(&content, &query, 10, SNIPPET_CONTEXT_LINES);
             for snippet in &snippets {
                 prop_assert!(
-                    snippet.to_lowercase().contains(&query),
+                    snippet.text.to_lowercase().contains(&query),
                     "Snippet {:?} does not contain query {:?}",
-                    snippet,
+                    snippet.text,
                     query
                 );
             }
@@ -670,7 +727,7 @@ mod tests {
             let content = "a\nb\nc\nmatch\nd\ne\nf";
             let snippets = extract_snippets(content, "match", 1, context_lines);
             prop_assert_eq!(snippets.len(), 1);
-            let line_count = snippets[0].lines().count();
+            let line_count = snippets[0].text.lines().count();
             // snippet should contain at most: context above + match + context below
             let expected_max = context_lines + 1 + context_lines;
             prop_assert!(
@@ -678,6 +735,8 @@ mod tests {
                 "Got {line_count} lines with context_lines={context_lines}, \
                  expected at most {expected_max}"
             );
+            // "match" is on line 4 (1-based)
+            prop_assert_eq!(snippets[0].line_offset, 4);
         }
     }
 

--- a/api/src/routes/mcp/docs.rs
+++ b/api/src/routes/mcp/docs.rs
@@ -1,4 +1,24 @@
-//! The documentation related tools for the Thorium MCP server
+//! Documentation browsing and search tools for the Thorium MCP server.
+//!
+//! These tools give AI agents progressive access to Thorium's documentation:
+//! 1. [`get_docs_toc`](ThoriumMCP::get_docs_toc) -- orientation via the table of contents
+//! 2. [`search_docs`](ThoriumMCP::search_docs) -- discovery via full-text search
+//! 3. [`get_doc_page`](ThoriumMCP::get_doc_page) -- deep reading via individual page fetch
+//!
+//! # `content` vs `structured_content`
+//!
+//! Each tool returns both `content` and `structured_content` in its
+//! [`CallToolResult`]. These serve different consumers:
+//!
+//! - **`content`** (required by the MCP spec) -- A human-readable text or JSON
+//!   representation intended for display in chat UIs and for models that only
+//!   inspect the `content` array.
+//! - **`structured_content`** (optional MCP extension) -- A machine-readable
+//!   JSON value with a stable schema, intended for programmatic consumers that
+//!   need to parse fields reliably without scraping text.
+//!
+//! Both fields carry the same information; `structured_content` simply makes it
+//! easier for tool-calling agents to extract specific values.
 
 use std::path::Path;
 
@@ -12,53 +32,59 @@ use tracing::instrument;
 
 use super::{McpConfig, ThoriumMCP};
 
-/// A single entry from the documentation table of contents
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+/// Maximum number of search results to return from `search_docs`.
+const MAX_SEARCH_RESULTS: usize = 10;
+
+/// Maximum number of context snippets per search result.
+const MAX_SNIPPETS_PER_PAGE: usize = 3;
+
+/// Number of context lines to include above and below each snippet match.
+const SNIPPET_CONTEXT_LINES: usize = 1;
+
+/// A single entry from the documentation table of contents.
+#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct TocEntry {
-    /// The display title of this documentation page
+    /// The display title of this documentation page.
     pub title: String,
-    /// The relative path to this documentation page
+    /// The relative path to this documentation page.
     pub path: String,
-    /// The nesting depth of this entry (0 = top level)
+    /// The nesting depth of this entry (0 = top level).
     pub depth: usize,
 }
 
-/// The params needed to get a specific documentation page
+/// The params needed to get a specific documentation page.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct DocPage {
-    /// The relative path to the documentation page (e.g. "concepts/files.md")
+    /// The relative path to the documentation page (e.g. "concepts/files.md").
     pub path: String,
 }
 
-/// The params needed to search the documentation
+/// The params needed to search the documentation.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SearchDocs {
-    /// The search query to find in the documentation
+    /// The search query to find in the documentation.
     pub query: String,
 }
 
-/// A single search result with context snippets
+/// A single search result with context snippets.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchResult {
-    /// The relative path to the matching documentation page
+    /// The relative path to the matching documentation page.
     pub path: String,
-    /// The title of the matching page
+    /// The title of the matching page.
     pub title: String,
-    /// The number of matches found in this page
+    /// The number of matches found in this page.
     pub match_count: usize,
-    /// Context snippets around the matches
+    /// Context snippets around the matches.
     pub snippets: Vec<String>,
 }
 
-/// Parse the SUMMARY.md file into a list of table of contents entries
+/// Parse the SUMMARY.md file into a list of table of contents entries.
 ///
-/// # Arguments
-///
-/// * `content` - The raw SUMMARY.md content
+/// Each line in SUMMARY.md is formatted as `"    - [Title](./path.md)"`
+/// where leading whitespace indicates nesting depth (4 spaces per level).
+/// Lines that don't contain a valid markdown link are skipped.
 fn parse_summary(content: &str) -> Vec<TocEntry> {
-    // Each line in SUMMARY.md is formatted as: "    - [Title](./path.md)"
-    // where the leading whitespace indicates nesting depth (4 spaces per level).
-    // Lines that don't contain a valid markdown link are skipped via filter_map.
     content
         .lines()
         .filter_map(|line| {
@@ -88,12 +114,20 @@ fn parse_summary(content: &str) -> Vec<TocEntry> {
         .collect()
 }
 
-/// Validate a documentation path to prevent directory traversal
+/// Validate a documentation path to prevent directory traversal.
 ///
-/// # Arguments
+/// Rejects paths containing `..` and verifies that the canonicalized target
+/// remains within the documentation root.
 ///
-/// * `docs_path` - The base documentation directory
-/// * `requested` - The requested relative path
+/// # Errors
+///
+/// Returns `ErrorData` with `INVALID_PARAMS` if:
+/// - The path contains `..` (directory traversal attempt)
+/// - The resolved path falls outside the documentation directory
+/// - The target file does not exist
+///
+/// Returns `ErrorData` with `INTERNAL_ERROR` if the base documentation
+/// directory cannot be canonicalized.
 fn validate_doc_path(docs_path: &Path, requested: &str) -> Result<std::path::PathBuf, ErrorData> {
     // reject paths with directory traversal components
     if requested.contains("..") {
@@ -129,49 +163,48 @@ fn validate_doc_path(docs_path: &Path, requested: &str) -> Result<std::path::Pat
     Ok(canonical_target)
 }
 
-/// Recursively collect all markdown file paths under a directory
+/// Recursively collect all markdown file paths under a directory.
 ///
-/// # Arguments
+/// # Errors
 ///
-/// * `dir` - The directory to walk
-/// * `paths` - The output vector to collect paths into
-fn collect_md_files(dir: &Path, paths: &mut Vec<std::path::PathBuf>) -> Result<(), std::io::Error> {
-    let entries = std::fs::read_dir(dir)?;
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_md_files(&path, paths)?;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
-            paths.push(path);
-        }
-    }
-    Ok(())
+/// Returns `std::io::Error` if the directory cannot be read or any entry
+/// within it cannot be inspected.
+fn collect_md_files(dir: &Path) -> Result<Vec<std::path::PathBuf>, std::io::Error> {
+    Ok(std::fs::read_dir(dir)?
+        .map(|entry| {
+            let path = entry?.path();
+            if path.is_dir() {
+                collect_md_files(&path)
+            } else {
+                Ok(vec![path])
+            }
+        })
+        .collect::<Result<Vec<Vec<_>>, _>>()?
+        .into_iter()
+        .flatten()
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+        .collect())
 }
 
-/// Extract the page title from markdown content (the first # heading)
-///
-/// # Arguments
-///
-/// * `content` - The raw markdown content
+/// Extract the page title from markdown content (the first `# ` heading).
 fn extract_title(content: &str) -> String {
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if let Some(title) = trimmed.strip_prefix("# ") {
-            return title.to_string();
-        }
-    }
-    "Untitled".to_string()
+    content
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("# ").map(String::from))
+        .unwrap_or_else(|| "Untitled".to_string())
 }
 
-/// Extract context snippets around search matches
+/// Extract context snippets around search matches.
 ///
-/// # Arguments
-///
-/// * `content` - The raw markdown content
-/// * `query_lower` - The lowercased search query
-/// * `max_snippets` - Maximum number of snippets to return
-fn extract_snippets(content: &str, query_lower: &str, max_snippets: usize) -> Vec<String> {
+/// Returns up to `max_snippets` text fragments, each containing the matching
+/// line plus `context_lines` lines of surrounding context. Adjacent matches
+/// are deduplicated to avoid overlapping snippets.
+fn extract_snippets(
+    content: &str,
+    query_lower: &str,
+    max_snippets: usize,
+    context_lines: usize,
+) -> Vec<String> {
     let lines: Vec<&str> = content.lines().collect();
     let mut snippets = Vec::new();
     let mut last_snippet_line: Option<usize> = None;
@@ -181,15 +214,15 @@ fn extract_snippets(content: &str, query_lower: &str, max_snippets: usize) -> Ve
             break;
         }
         if line.to_lowercase().contains(query_lower) {
-            // skip if too close to the previous snippet
+            // skip if too close to the previous snippet to avoid overlap
             if let Some(last) = last_snippet_line {
-                if i <= last + 2 {
+                if i <= last + context_lines + 1 {
                     continue;
                 }
             }
-            // grab the matching line with one line of context on each side
-            let start = i.saturating_sub(1);
-            let end = (i + 2).min(lines.len());
+            // grab the matching line with context on each side
+            let start = i.saturating_sub(context_lines);
+            let end = (i + context_lines + 1).min(lines.len());
             let snippet: String = lines[start..end].join("\n");
             snippets.push(snippet);
             last_snippet_line = Some(i);
@@ -200,11 +233,13 @@ fn extract_snippets(content: &str, query_lower: &str, max_snippets: usize) -> Ve
 
 #[tool_router(router = docs_router, vis = "pub")]
 impl ThoriumMCP {
-    /// Get the table of contents for the Thorium documentation
+    /// Get the table of contents for the Thorium documentation.
     ///
-    /// # Arguments
+    /// # Errors
     ///
-    /// * `parts` - The request parts required to validate authorization
+    /// Returns `ErrorData` with `INTERNAL_ERROR` if `SUMMARY.md` cannot be
+    /// read from the configured docs path. Returns an authentication error
+    /// if the MCP session token is invalid.
     #[tool(
         name = "get_docs_toc",
         description = "Get the table of contents for the Thorium documentation. Returns a structured list of all documentation pages with their titles, paths, and nesting depth. Call this first to understand what documentation is available."
@@ -214,9 +249,8 @@ impl ThoriumMCP {
         &self,
         RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
-        // validate authorization
         McpConfig::grab_token(&parts)?;
-        // read SUMMARY.md
+
         let summary_path = self.conf.docs_path.join("SUMMARY.md");
         let content =
             tokio::fs::read_to_string(&summary_path)
@@ -226,26 +260,26 @@ impl ThoriumMCP {
                     message: format!("Failed to read documentation index: {e}").into(),
                     data: None,
                 })?;
-        // parse the summary into structured entries
+
         let entries = parse_summary(&content);
-        // serialize our entries
         let serialized = serde_json::to_value(&entries).unwrap();
-        // build our result
-        let result = CallToolResult {
+
+        Ok(CallToolResult {
             content: vec![Content::json(&entries)?],
             structured_content: Some(serialized),
             is_error: Some(false),
             meta: None,
-        };
-        Ok(result)
+        })
     }
 
-    /// Get the content of a specific documentation page
+    /// Get the content of a specific documentation page.
     ///
-    /// # Arguments
+    /// # Errors
     ///
-    /// * `parameters` - The parameters containing the page path
-    /// * `parts` - The request parts required to validate authorization
+    /// Returns `ErrorData` with `INVALID_PARAMS` if the path is invalid or
+    /// attempts directory traversal. Returns `INTERNAL_ERROR` if the file
+    /// cannot be read. Returns an authentication error if the MCP session
+    /// token is invalid.
     #[tool(
         name = "get_doc_page",
         description = "Get the content of a specific Thorium documentation page by its relative path (e.g. 'concepts/files.md'). Use get_docs_toc first to discover available page paths."
@@ -256,11 +290,9 @@ impl ThoriumMCP {
         Parameters(DocPage { path }): Parameters<DocPage>,
         RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
-        // validate authorization
         McpConfig::grab_token(&parts)?;
-        // validate and resolve the path
+
         let full_path = validate_doc_path(&self.conf.docs_path, &path)?;
-        // read the file
         let content =
             tokio::fs::read_to_string(&full_path)
                 .await
@@ -269,27 +301,30 @@ impl ThoriumMCP {
                     message: format!("Failed to read documentation page: {e}").into(),
                     data: None,
                 })?;
-        // build our result with the raw markdown as text content
+
         let serialized = serde_json::to_value(&serde_json::json!({
             "path": path,
             "content": content,
         }))
         .unwrap();
-        let result = CallToolResult {
+
+        Ok(CallToolResult {
             content: vec![Content::text(content)],
             structured_content: Some(serialized),
             is_error: Some(false),
             meta: None,
-        };
-        Ok(result)
+        })
     }
 
-    /// Search across all Thorium documentation pages
+    /// Search across all Thorium documentation pages.
     ///
-    /// # Arguments
+    /// # Errors
     ///
-    /// * `parameters` - The parameters containing the search query
-    /// * `parts` - The request parts required to validate authorization
+    /// Returns `ErrorData` with `INVALID_PARAMS` if the query is empty.
+    /// Returns `INTERNAL_ERROR` if the documentation directory cannot be
+    /// traversed. Returns an authentication error if the MCP session token
+    /// is invalid. Individual file read failures are logged as warnings and
+    /// skipped rather than aborting the entire search.
     #[tool(
         name = "search_docs",
         description = "Search across all Thorium documentation pages for a query string. Returns matching pages with titles, match counts, and context snippets. Use this to find documentation about a specific topic."
@@ -300,9 +335,8 @@ impl ThoriumMCP {
         Parameters(SearchDocs { query }): Parameters<SearchDocs>,
         RmcpExtension(parts): RmcpExtension<axum::http::request::Parts>,
     ) -> Result<CallToolResult, ErrorData> {
-        // validate authorization
         McpConfig::grab_token(&parts)?;
-        // validate query is not empty
+
         if query.trim().is_empty() {
             return Err(ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -310,56 +344,67 @@ impl ThoriumMCP {
                 data: None,
             });
         }
+
         let query_lower = query.to_lowercase();
-        // collect all markdown files
-        let mut md_files = Vec::new();
-        collect_md_files(&self.conf.docs_path, &mut md_files).map_err(
-            |e| ErrorData {
+
+        let md_files =
+            collect_md_files(&self.conf.docs_path).map_err(|e| ErrorData {
                 code: rmcp::model::ErrorCode::INTERNAL_ERROR,
                 message: format!("Failed to read documentation directory: {e}").into(),
                 data: None,
-            },
-        )?;
-        // search each file
-        let mut results: Vec<SearchResult> = Vec::new();
-        for file_path in &md_files {
-            let content = match tokio::fs::read_to_string(file_path).await {
-                Ok(c) => c,
-                Err(_) => continue,
-            };
-            let content_lower = content.to_lowercase();
-            let match_count = content_lower.matches(&query_lower).count();
-            if match_count == 0 {
-                continue;
-            }
-            // get the relative path from the docs root
-            let rel_path = file_path
-                .strip_prefix(&self.conf.docs_path)
-                .unwrap_or(file_path)
-                .to_string_lossy()
-                .to_string();
-            let title = extract_title(&content);
-            let snippets = extract_snippets(&content, &query_lower, 3);
-            results.push(SearchResult {
-                path: rel_path,
-                title,
-                match_count,
-                snippets,
-            });
-        }
-        // sort by match count descending and limit to top 10
+            })?;
+
+        let mut results: Vec<SearchResult> = md_files
+            .iter()
+            .filter_map(|file_path| {
+                let content = match std::fs::read_to_string(file_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %file_path.display(),
+                            "Failed to read documentation file: {e}"
+                        );
+                        return None;
+                    }
+                };
+
+                let match_count =
+                    content.to_lowercase().matches(&query_lower).count();
+                if match_count == 0 {
+                    return None;
+                }
+
+                let rel_path = file_path
+                    .strip_prefix(&self.conf.docs_path)
+                    .unwrap_or(file_path)
+                    .to_string_lossy()
+                    .to_string();
+
+                Some(SearchResult {
+                    title: extract_title(&content),
+                    snippets: extract_snippets(
+                        &content,
+                        &query_lower,
+                        MAX_SNIPPETS_PER_PAGE,
+                        SNIPPET_CONTEXT_LINES,
+                    ),
+                    path: rel_path,
+                    match_count,
+                })
+            })
+            .collect();
+
         results.sort_by(|a, b| b.match_count.cmp(&a.match_count));
-        results.truncate(10);
-        // serialize our results
+        results.truncate(MAX_SEARCH_RESULTS);
+
         let serialized = serde_json::to_value(&results).unwrap();
-        // build our result
-        let result = CallToolResult {
+
+        Ok(CallToolResult {
             content: vec![Content::json(&results)?],
             structured_content: Some(serialized),
             is_error: Some(false),
             meta: None,
-        };
-        Ok(result)
+        })
     }
 }
 
@@ -368,6 +413,8 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::PathBuf;
+
+    use proptest::prelude::*;
 
     // ── parse_summary ──────────────────────────────────────────────
 
@@ -383,55 +430,61 @@ mod tests {
         - [Advanced Login](./getting_started/advanced_login.md)
 ";
         let entries = parse_summary(content);
-        assert_eq!(entries.len(), 5);
-
-        assert_eq!(entries[0].title, "Intro");
-        assert_eq!(entries[0].path, "intro.md");
-        assert_eq!(entries[0].depth, 0);
-
-        assert_eq!(entries[1].title, "Getting Started");
-        assert_eq!(entries[1].path, "getting_started/getting_started.md");
-        assert_eq!(entries[1].depth, 0);
-
-        assert_eq!(entries[2].title, "Registration");
-        assert_eq!(entries[2].path, "getting_started/registration.md");
-        assert_eq!(entries[2].depth, 1);
-
-        assert_eq!(entries[3].title, "Login");
-        assert_eq!(entries[3].depth, 1);
-
-        assert_eq!(entries[4].title, "Advanced Login");
-        assert_eq!(entries[4].depth, 2);
+        assert_eq!(
+            entries,
+            vec![
+                TocEntry {
+                    title: "Intro".into(),
+                    path: "intro.md".into(),
+                    depth: 0,
+                },
+                TocEntry {
+                    title: "Getting Started".into(),
+                    path: "getting_started/getting_started.md".into(),
+                    depth: 0,
+                },
+                TocEntry {
+                    title: "Registration".into(),
+                    path: "getting_started/registration.md".into(),
+                    depth: 1,
+                },
+                TocEntry {
+                    title: "Login".into(),
+                    path: "getting_started/login.md".into(),
+                    depth: 1,
+                },
+                TocEntry {
+                    title: "Advanced Login".into(),
+                    path: "getting_started/advanced_login.md".into(),
+                    depth: 2,
+                },
+            ]
+        );
     }
 
-    #[test]
-    fn parse_summary_strips_dot_slash_prefix() {
-        let content = "- [Page](./some/path.md)\n- [Other](other/path.md)\n";
-        let entries = parse_summary(content);
-        assert_eq!(entries[0].path, "some/path.md");
-        assert_eq!(entries[1].path, "other/path.md");
-    }
+    proptest! {
+        #[test]
+        fn parse_summary_roundtrip(
+            title in "[A-Za-z]{1,30}",
+            path in "[a-z]{1,10}/[a-z]{1,10}\\.md",
+            depth in 0..5usize,
+        ) {
+            let indent = " ".repeat(depth * 4);
+            let line = format!("{indent}- [{title}](./{path})");
+            let entries = parse_summary(&line);
+            prop_assert_eq!(entries.len(), 1);
+            prop_assert_eq!(&entries[0].title, &title);
+            prop_assert_eq!(&entries[0].path, &path);
+            prop_assert_eq!(entries[0].depth, depth);
+        }
 
-    #[test]
-    fn parse_summary_skips_non_link_lines() {
-        let content = "\
-# Summary
-
-Some random text here.
-
-- [Actual Link](./page.md)
-
-Another non-link line.
-";
-        let entries = parse_summary(content);
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].title, "Actual Link");
-    }
-
-    #[test]
-    fn parse_summary_empty_input() {
-        let entries = parse_summary("");
-        assert!(entries.is_empty());
+        #[test]
+        fn parse_summary_skips_non_links(
+            text in "[A-Za-z0-9 ]{1,50}",
+        ) {
+            let entries = parse_summary(&text);
+            prop_assert!(entries.is_empty());
+        }
     }
 
     #[test]
@@ -440,14 +493,18 @@ Another non-link line.
             .join("docs")
             .join("src")
             .join("SUMMARY.md");
-        if !summary_path.exists() {
-            return; // skip if docs aren't available
-        }
+        assert!(
+            summary_path.exists(),
+            "Real SUMMARY.md not found at {}",
+            summary_path.display()
+        );
         let content = fs::read_to_string(&summary_path).unwrap();
         let entries = parse_summary(&content);
-        // the real SUMMARY.md has many entries — just verify it parsed something
-        assert!(entries.len() > 10, "Expected many TOC entries, got {}", entries.len());
-        // first entry should be Intro
+        assert!(
+            entries.len() > 10,
+            "Expected many TOC entries, got {}",
+            entries.len()
+        );
         assert_eq!(entries[0].title, "Intro");
         assert_eq!(entries[0].path, "intro.md");
         assert_eq!(entries[0].depth, 0);
@@ -455,23 +512,24 @@ Another non-link line.
 
     // ── validate_doc_path ──────────────────────────────────────────
 
-    #[test]
-    fn validate_doc_path_rejects_traversal() {
-        let docs = PathBuf::from("/tmp");
-        let err = validate_doc_path(&docs, "../etc/passwd").unwrap_err();
-        assert!(err.message.contains("directory traversal"));
-    }
-
-    #[test]
-    fn validate_doc_path_rejects_hidden_traversal() {
-        let docs = PathBuf::from("/tmp");
-        let err = validate_doc_path(&docs, "foo/../../etc/passwd").unwrap_err();
-        assert!(err.message.contains("directory traversal"));
+    proptest! {
+        #[test]
+        fn validate_doc_path_always_rejects_traversal(
+            prefix in "[a-z]{0,5}",
+            suffix in "[a-z]{1,10}",
+        ) {
+            let docs = tempfile::tempdir().unwrap();
+            let path = format!("{prefix}/../{suffix}");
+            let result = validate_doc_path(docs.path(), &path);
+            prop_assert!(result.is_err());
+            prop_assert!(
+                result.unwrap_err().message.contains("directory traversal")
+            );
+        }
     }
 
     #[test]
     fn validate_doc_path_accepts_valid_path() {
-        // create a temp file to validate against
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("test.md");
         fs::write(&file_path, "# Test").unwrap();
@@ -493,32 +551,27 @@ Another non-link line.
     #[test]
     fn collect_md_files_finds_markdown() {
         let dir = tempfile::tempdir().unwrap();
-        // create some files
-        fs::write(dir.path().join("page.md"), "# Page").unwrap();
-        fs::write(dir.path().join("readme.txt"), "not markdown").unwrap();
-        fs::write(dir.path().join("image.png"), "not markdown").unwrap();
-        // create a subdirectory with another md file
-        let sub = dir.path().join("sub");
+        fs::write(dir.path().join("dragons.md"), "# Here Be Dragons").unwrap();
+        fs::write(dir.path().join("treasure_map.txt"), "X marks the spot").unwrap();
+        fs::write(dir.path().join("loot.png"), "not markdown").unwrap();
+        let sub = dir.path().join("dungeon");
         fs::create_dir(&sub).unwrap();
-        fs::write(sub.join("nested.md"), "# Nested").unwrap();
+        fs::write(sub.join("boss_fight.md"), "# The Final Boss").unwrap();
 
-        let mut paths = Vec::new();
-        collect_md_files(dir.path(), &mut paths).unwrap();
-
+        let paths = collect_md_files(dir.path()).unwrap();
         assert_eq!(paths.len(), 2);
         let names: Vec<String> = paths
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
             .collect();
-        assert!(names.contains(&"page.md".to_string()));
-        assert!(names.contains(&"nested.md".to_string()));
+        assert!(names.contains(&"dragons.md".to_string()));
+        assert!(names.contains(&"boss_fight.md".to_string()));
     }
 
     #[test]
     fn collect_md_files_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let mut paths = Vec::new();
-        collect_md_files(dir.path(), &mut paths).unwrap();
+        let paths = collect_md_files(dir.path()).unwrap();
         assert!(paths.is_empty());
     }
 
@@ -527,109 +580,118 @@ Another non-link line.
         let docs_src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("docs")
             .join("src");
-        if !docs_src.exists() {
-            return; // skip if docs aren't available
-        }
-        let mut paths = Vec::new();
-        collect_md_files(&docs_src, &mut paths).unwrap();
-        // the real docs have 80+ markdown files
-        assert!(paths.len() > 50, "Expected many md files, got {}", paths.len());
-        // all should be .md files
+        assert!(
+            docs_src.exists(),
+            "Real docs not found at {}",
+            docs_src.display()
+        );
+        let paths = collect_md_files(&docs_src).unwrap();
+        assert!(
+            paths.len() > 50,
+            "Expected many md files, got {}",
+            paths.len()
+        );
         assert!(paths.iter().all(|p| p.extension().unwrap() == "md"));
     }
 
     // ── extract_title ──────────────────────────────────────────────
 
-    #[test]
-    fn extract_title_finds_h1() {
-        let content = "Some preamble\n# My Title\n\nBody text here.";
-        assert_eq!(extract_title(content), "My Title");
-    }
+    proptest! {
+        #[test]
+        fn extract_title_finds_h1(
+            title in "[A-Za-z]{1,30}",
+        ) {
+            let content = format!("some preamble\n## Not This\n# {title}\nBody text.");
+            prop_assert_eq!(extract_title(&content), title);
+        }
 
-    #[test]
-    fn extract_title_returns_first_h1() {
-        let content = "# First Title\n## Subtitle\n# Second Title";
-        assert_eq!(extract_title(content), "First Title");
-    }
-
-    #[test]
-    fn extract_title_ignores_h2_and_deeper() {
-        let content = "## Not A Title\n### Also Not\nNo headings here.";
-        assert_eq!(extract_title(content), "Untitled");
-    }
-
-    #[test]
-    fn extract_title_handles_empty_content() {
-        assert_eq!(extract_title(""), "Untitled");
-    }
-
-    #[test]
-    fn extract_title_handles_leading_whitespace() {
-        let content = "  # Indented Title\n";
-        assert_eq!(extract_title(content), "Indented Title");
+        #[test]
+        fn extract_title_untitled_without_h1(
+            body in "[a-z ]{1,100}",
+        ) {
+            // body only contains lowercase letters and spaces, never "# "
+            prop_assert_eq!(extract_title(&body), "Untitled");
+        }
     }
 
     // ── extract_snippets ───────────────────────────────────────────
 
-    #[test]
-    fn extract_snippets_basic() {
-        let content = "line 0\nline 1\nfoo bar baz\nline 3\nline 4\n";
-        let snippets = extract_snippets(content, "foo", 3);
-        assert_eq!(snippets.len(), 1);
-        // should include the line before, the match line, and the line after
-        assert!(snippets[0].contains("line 1"));
-        assert!(snippets[0].contains("foo bar baz"));
-        assert!(snippets[0].contains("line 3"));
+    proptest! {
+        #[test]
+        fn extract_snippets_respects_max(
+            max_snippets in 1..10usize,
+        ) {
+            // 20 well-spaced matches should never exceed max_snippets
+            let content: String = (0..20)
+                .map(|i| format!("match line {i}\npadding\npadding\npadding\n"))
+                .collect();
+            let snippets =
+                extract_snippets(&content, "match", max_snippets, SNIPPET_CONTEXT_LINES);
+            prop_assert!(snippets.len() <= max_snippets);
+        }
+
+        #[test]
+        fn extract_snippets_no_false_positives(
+            query in "[xyz]{3,8}",
+            content in "[abc ]{10,200}",
+        ) {
+            // content with only a/b/c/spaces cannot match xyz-only queries
+            let snippets = extract_snippets(
+                &content,
+                &query.to_lowercase(),
+                5,
+                SNIPPET_CONTEXT_LINES,
+            );
+            prop_assert!(snippets.is_empty());
+        }
+
+        #[test]
+        fn extract_snippets_each_contains_query(
+            query in "[a-z]{3,6}",
+        ) {
+            let content =
+                format!("before\n{query} appears here\nafter\nmore\n{query} again\nend");
+            let snippets =
+                extract_snippets(&content, &query, 10, SNIPPET_CONTEXT_LINES);
+            for snippet in &snippets {
+                prop_assert!(
+                    snippet.to_lowercase().contains(&query),
+                    "Snippet {:?} does not contain query {:?}",
+                    snippet,
+                    query
+                );
+            }
+        }
+
+        #[test]
+        fn extract_snippets_configurable_context(
+            context_lines in 0..5usize,
+        ) {
+            let content = "a\nb\nc\nmatch\nd\ne\nf";
+            let snippets = extract_snippets(content, "match", 1, context_lines);
+            prop_assert_eq!(snippets.len(), 1);
+            let line_count = snippets[0].lines().count();
+            // snippet should contain at most: context above + match + context below
+            let expected_max = context_lines + 1 + context_lines;
+            prop_assert!(
+                line_count <= expected_max,
+                "Got {line_count} lines with context_lines={context_lines}, \
+                 expected at most {expected_max}"
+            );
+        }
     }
 
-    #[test]
-    fn extract_snippets_case_insensitive() {
-        let content = "Hello World\nFOO BAR\nGoodbye";
-        let snippets = extract_snippets(content, "foo", 3);
-        assert_eq!(snippets.len(), 1);
-        assert!(snippets[0].contains("FOO BAR"));
-    }
-
-    #[test]
-    fn extract_snippets_respects_max() {
-        let content = "match1\n\n\n\nmatch2\n\n\n\nmatch3\n\n\n\nmatch4\n";
-        let snippets = extract_snippets(content, "match", 2);
-        assert_eq!(snippets.len(), 2);
-    }
-
-    #[test]
-    fn extract_snippets_skips_adjacent_matches() {
-        // matches on consecutive lines should be collapsed into one snippet
-        let content = "foo line 1\nfoo line 2\nfoo line 3\n\n\n\nfoo line 7\n";
-        let snippets = extract_snippets(content, "foo", 3);
-        // first match at line 0 grabs context [0..2], so lines 1-2 are within +2
-        // line 7 match (index 6) is far enough away
-        assert_eq!(snippets.len(), 2);
-    }
-
-    #[test]
-    fn extract_snippets_match_at_first_line() {
-        let content = "match here\nline 1\nline 2\n";
-        let snippets = extract_snippets(content, "match", 3);
-        assert_eq!(snippets.len(), 1);
-        // should not crash on saturating_sub(1) when match is at index 0
-        assert!(snippets[0].contains("match here"));
-        assert!(snippets[0].contains("line 1"));
-    }
-
-    #[test]
-    fn extract_snippets_match_at_last_line() {
-        let content = "line 0\nline 1\nmatch here";
-        let snippets = extract_snippets(content, "match", 3);
-        assert_eq!(snippets.len(), 1);
-        assert!(snippets[0].contains("line 1"));
-        assert!(snippets[0].contains("match here"));
-    }
-
-    #[test]
-    fn extract_snippets_no_matches() {
-        let content = "nothing relevant here\nat all\n";
-        let snippets = extract_snippets(content, "nonexistent", 3);
-        assert!(snippets.is_empty());
+    proptest! {
+        #[test]
+        fn extract_snippets_deduplicates_adjacent(
+            context_lines in 1..4usize,
+        ) {
+            // consecutive matches should be collapsed by deduplication
+            let content = "foo line 1\nfoo line 2\nfoo line 3\n\n\n\n\n\nfoo distant\n";
+            let snippets = extract_snippets(content, "foo", 10, context_lines);
+            // 4 total matches but consecutive ones should be deduped
+            prop_assert!(snippets.len() < 4);
+            prop_assert!(!snippets.is_empty());
+        }
     }
 }


### PR DESCRIPTION
  # feat(mcp): Add documentation browsing and search tools #                                                                                                                                                   
                                                                            
  ## 🗣 Description ##                                                                                                                                                                                          
                                                                                                                                                                                                               
  Adds three new MCP tools that allow AI agents to browse and search Thorium's documentation through the existing MCP server at `/mcp`:

  - **`get_docs_toc`** — Returns the structured table of contents (titles, paths, nesting depth) parsed from `SUMMARY.md`. An agent calls this first to orient itself.
  - **`get_doc_page`** — Fetches a specific documentation page's raw markdown by relative path (e.g. `concepts/files.md`). Includes path traversal protection via canonicalization.
  - **`search_docs`** — Case-insensitive full-text search across all 90+ markdown files. Returns the top 10 matching pages ranked by match count, with page titles and context snippets.

  Unlike the existing MCP tools which use the loopback HTTP client pattern to call Thorium's REST API, the docs tools read markdown files directly from the container filesystem. This is simpler and
  appropriate since docs are static content that don't require database access or complex auth beyond validating the MCP session token.

  **Files changed:**
  - `api/src/routes/mcp/docs.rs` (new) — Three MCP tool handlers with helper functions and 24 unit tests
  - `api/src/routes/mcp.rs` — Added `docs_path: PathBuf` to `McpConfig`, registered docs module and router, removed `Copy` derive (PathBuf isn't Copy), added `.clone()` in mount closure
  - `api/src/conf.rs` — Added `docs_src` field to `Assets` struct with default path `"docs/src"`
  - `api/Cargo.toml` — Added `tempfile` dev-dependency for unit tests
  - `Cargo.lock` — Updated to reflect new dev-dependency
  - `Dockerfile` — Added `ADD ./api/docs/src docs/src` to include raw markdown source in the container image

  ## 💭 Motivation and context ##

  Currently, an AI agent connected to Thorium's MCP server has no way to learn how Thorium works — it can interact with files, images, and pipelines but can't access any documentation. This means agents
  require external context or human guidance to understand Thorium's concepts, workflows, and configuration.

  These tools give agents a self-service path to learn Thorium through a progressive disclosure pattern: get the table of contents for orientation, search for specific topics, then fetch individual pages as
  needed. This keeps agent context windows lean while providing full access to all documentation.

  ## 🧪 Testing ##

  **Unit tests (24 tests, all passing):**

  Run with: `cargo +nightly test -p thorium-api --lib -- mcp::docs::tests`

  | Function | Tests | Coverage |
  |----------|-------|----------|
  | `parse_summary` | 5 | Basic parsing, depth levels, `./` stripping, non-link lines, empty input, real SUMMARY.md |
  | `validate_doc_path` | 4 | Traversal rejection (`..`), nested traversal, valid path acceptance, nonexistent file |
  | `collect_md_files` | 3 | Finds .md only, ignores other extensions, recurses subdirs, empty dir, real docs tree |
  | `extract_title` | 5 | Finds H1, returns first H1, ignores H2+, empty content, leading whitespace |
  | `extract_snippets` | 7 | Basic context, case insensitivity, max limit, adjacent dedup, first/last line edges, no matches |

  Three tests also validate against the real documentation source files on disk.

  **Integration testing (recommended for reviewers):**
  - Connect an MCP client to `/mcp` and verify `get_docs_toc` returns structured TOC entries
  - Verify `get_doc_page` with a valid path (e.g. `intro.md`) returns markdown content
  - Verify `get_doc_page` with a traversal path (e.g. `../../../etc/passwd`) returns an error
  - Verify `search_docs` with `"redis"` returns relevant results with snippets from deployment docs
  - Verify existing MCP tools (`get_sample`, `list_images`, etc.) still function after `McpConfig` changes

  ## ✅ Pre-approval checklist ##

  - [x] This PR has an informative and human-readable title.
  - [x] Changes are limited to a single goal - *eschew scope creep!*
  - [x] *All* future TODOs are captured in issues, which are referenced in code comments.
  - [x] All relevant type-of-change labels have been added.
  - [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
  - [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
  - [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
  - [x] Tests have been added and/or modified to cover the changes in this PR.
  - [x] All new and existing tests pass.
  - [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is
  versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
  - [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

  ## ✅ Pre-merge checklist ##

  - [ ] Revert dependencies to default branches.
  - [ ] Finalize version.

  ## ✅ Post-merge checklist ##

  - [ ] Create a release (necessary if and only if the version was bumped).